### PR TITLE
Add pick functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Assuming we have users and their related tables resembling the following structu
 ]
 ```
 
-We can users by their hobbies with `users?filters[profile.hobbies.name]=^Cook`. 
+We can filter users by their hobbies with `users?filters[profile.hobbies.name]=^Cook`. 
 
 This filter can be read as `select users with whose profile.hobbies.name begins with "Cook"`
 
@@ -199,6 +199,11 @@ We can use `AND` and `OR` statements to build filters such as `users?filters[use
 ```
 
 and this filter can be read as `select (users with username Bobby) OR (users with username Johnny whose profile.favorite_cheese attribute is Gouda)`.
+
+## Other Parameters
+### Pick
+We can limit the amount of data that comes back with your query by adding `pick` to the URL.
+Usage: `https://api.yourdomain.com/1.0/users?pick=id,username,occupation`
 
 ## Model Setup
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ and this filter can be read as `select (users with username Bobby) OR (users wit
 ## Other Parameters
 ### Pick
 We can limit the amount of data that comes back with your query by adding `pick` to the URL.
-Usage: `https://api.yourdomain.com/1.0/users?pick=id,username,occupation`
+Usage: 
+  * `https://api.yourdomain.com/1.0/users?pick=id,username,occupation`
+  * `https://api.yourdomain.com/1.0/users?pick[]=id&pick[]=username&pick[]=occupation`
 
 ## Model Setup
 

--- a/src/Contracts/QueryModifier.php
+++ b/src/Contracts/QueryModifier.php
@@ -113,7 +113,7 @@ interface QueryModifier
     public function addPick(string $name): self;
 
     /**
-     * Add a single pick
+     * Add one or more picks
      * @param string[] $names
      * @return QueryModifier
      */

--- a/src/Contracts/QueryModifier.php
+++ b/src/Contracts/QueryModifier.php
@@ -106,6 +106,20 @@ interface QueryModifier
     public function addFilter(string $key, string $value);
 
     /**
+     * Add a single pick
+     * @param string $name
+     * @return QueryModifier
+     */
+    public function addPick(string $name): self;
+
+    /**
+     * Add a single pick
+     * @param string[] $names
+     * @return QueryModifier
+     */
+    public function addPicks(array $names): self;
+
+    /**
      * Add a single modifier
      *
      * @param \Closure $modifier
@@ -175,4 +189,19 @@ interface QueryModifier
      * @return array
      */
     public function getSortOrder(): array;
+
+    /**
+     * Get picked fields
+     *
+     * @return array
+     */
+    public function getPicks(): ?array;
+
+    /**
+     * Set picked fields
+     *
+     * @param string[] $names
+     * @return self
+     */
+    public function setPicks(array $names): self;
 }

--- a/src/EloquentQueryModifier.php
+++ b/src/EloquentQueryModifier.php
@@ -396,7 +396,7 @@ class EloquentQueryModifier implements QueryModifier
         $columns       = $this->getFields($temp_instance);
 
         if ($picks_exist) {
-            $this->query()->select($this->picks);
+            $this->query()->select(array_intersect($columns, $this->picks));
         }
 
         if ($filters_exist) {

--- a/src/EloquentQueryModifier.php
+++ b/src/EloquentQueryModifier.php
@@ -14,7 +14,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -71,6 +70,13 @@ class EloquentQueryModifier implements QueryModifier
      * @var array
      */
     private $aggregate = [];
+
+    /**
+     * Selected fields
+     *
+     * @var string[]|null
+     */
+    private array $picks = [];
 
     /**
      * Query storage
@@ -378,15 +384,20 @@ class EloquentQueryModifier implements QueryModifier
         $sorts_exist     = ! empty($sort_order_options);
         $group_exist     = ! empty($group_by);
         $aggregate_exist = ! empty($aggregate);
+        $picks_exist     = ! empty($this->picks);
 
         // No modifications to apply
-        if (! $filters_exist && ! $sorts_exist && ! $group_exist && ! $aggregate_exist) {
+        if (! $picks_exist && ! $filters_exist && ! $sorts_exist && ! $group_exist && ! $aggregate_exist) {
             return $this;
         }
 
         // Make a mock instance so we can describe its columns
         $temp_instance = new $model_class();
         $columns       = $this->getFields($temp_instance);
+
+        if ($picks_exist) {
+            $this->query()->select($this->picks);
+        }
 
         if ($filters_exist) {
             $this->filterQuery($filters, $access_compiler, $columns, $temp_instance);
@@ -650,5 +661,29 @@ class EloquentQueryModifier implements QueryModifier
         } else {
             $query->orderBy("$table.$field", $direction);
         }
+    }
+
+    public function addPick(string $name): QueryModifier
+    {
+        $this->addPicks(!empty($name) ? [$name] : []);
+
+        return $this;
+    }
+
+    public function addPicks(array $names): self
+    {
+        return $this->setPicks(array_merge($this->picks, $names));
+    }
+
+    public function getPicks(): ?array
+    {
+        return $this->picks;
+    }
+
+    public function setPicks(array $names): self
+    {
+        $this->picks = array_values(array_unique($names));
+
+        return $this;
     }
 }

--- a/src/EloquentQueryModifier.php
+++ b/src/EloquentQueryModifier.php
@@ -663,7 +663,7 @@ class EloquentQueryModifier implements QueryModifier
         }
     }
 
-    public function addPick(string $name): QueryModifier
+    public function addPick(string $name): self
     {
         $this->addPicks(!empty($name) ? [$name] : []);
 

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -202,8 +202,7 @@ class Filter implements QueryFilterContainer
                     $query->whereHas(
                         $relation,
                         function ($query) use ($method, $column, $filter) {
-
-                        // Check if the column is a primary key of the model
+                            // Check if the column is a primary key of the model
                             // within the query. If it is, we should use the
                             // qualified key instead. It's important when this is a
                             // many to many relationship query.

--- a/src/Middleware/RepositoryMiddleware.php
+++ b/src/Middleware/RepositoryMiddleware.php
@@ -66,6 +66,7 @@ class RepositoryMiddleware
         $repository->setModelClass($model_class)->setInput($input);
 
         $repository->modify()
+            ->setPicks((array) $request->get('pick'))
             ->setFilters((array) $request->get('filters'))
             ->setSortOrder((array) $request->get('sort'))
             ->setGroupBy((array) $request->get('group'))

--- a/src/Middleware/RepositoryMiddleware.php
+++ b/src/Middleware/RepositoryMiddleware.php
@@ -66,25 +66,31 @@ class RepositoryMiddleware
         $repository->setModelClass($model_class)->setInput($input);
 
         $repository->modify()
+            ->setPicks($this->parsePickQueryParameter($request))
             ->setFilters((array) $request->get('filters'))
             ->setSortOrder((array) $request->get('sort'))
             ->setGroupBy((array) $request->get('group'))
             ->setEagerLoads((array) $request->get('include'))
             ->setAggregate((array) $request->get('aggregate'));
 
-        //Clean up comma separated pick list and explode it into an array
-        if ($request->has('pick') && is_string($request->get('pick')) && strlen($request->get('pick'))) {
-            $parsedPicks = array_filter(
-                explode(',', str_replace(' ', '', $request->get('pick'))),
-                'strlen'
-            );
-            if ($parsedPicks) {
-                $repository->modify()->addPicks($parsedPicks);
-            }
-        }
-
-        $repository->accessControl()->setDepthRestriction(config('pouch.eager_load_depth'));
+        //$repository->accessControl()->setDepthRestriction(config('pouch.eager_load_depth'));
 
         return $repository;
+    }
+
+    protected function parsePickQueryParameter(Request $request): array
+    {
+        $pick = $request->get('pick');
+        if (is_array($pick)) {
+            return $pick;
+        } else if (isset($pick) && is_string($pick) && strlen($pick)) {
+            //Clean up comma separated pick list and explode it into an array
+            return array_filter(
+                explode(',', str_replace(' ', '', $pick)),
+                'strlen'
+            );
+        } else {
+            return [];
+        }
     }
 }

--- a/src/Middleware/RepositoryMiddleware.php
+++ b/src/Middleware/RepositoryMiddleware.php
@@ -66,12 +66,22 @@ class RepositoryMiddleware
         $repository->setModelClass($model_class)->setInput($input);
 
         $repository->modify()
-            ->setPicks((array) $request->get('pick'))
             ->setFilters((array) $request->get('filters'))
             ->setSortOrder((array) $request->get('sort'))
             ->setGroupBy((array) $request->get('group'))
             ->setEagerLoads((array) $request->get('include'))
             ->setAggregate((array) $request->get('aggregate'));
+
+        //Clean up comma separated pick list and explode it into an array
+        if ($request->has('pick') && is_string($request->get('pick')) && strlen($request->get('pick'))) {
+            $parsedPicks = array_filter(
+                explode(',', str_replace(' ', '', $request->get('pick'))),
+                'strlen'
+            );
+            if ($parsedPicks) {
+                $repository->modify()->addPicks($parsedPicks);
+            }
+        }
 
         $repository->accessControl()->setDepthRestriction(config('pouch.eager_load_depth'));
 

--- a/src/Middleware/RepositoryMiddleware.php
+++ b/src/Middleware/RepositoryMiddleware.php
@@ -73,7 +73,7 @@ class RepositoryMiddleware
             ->setEagerLoads((array) $request->get('include'))
             ->setAggregate((array) $request->get('aggregate'));
 
-        //$repository->accessControl()->setDepthRestriction(config('pouch.eager_load_depth'));
+        $repository->accessControl()->setDepthRestriction(config('pouch.eager_load_depth'));
 
         return $repository;
     }
@@ -83,7 +83,7 @@ class RepositoryMiddleware
         $pick = $request->get('pick');
         if (is_array($pick)) {
             return $pick;
-        } else if (isset($pick) && is_string($pick) && strlen($pick)) {
+        } elseif (isset($pick) && is_string($pick) && strlen($pick)) {
             //Clean up comma separated pick list and explode it into an array
             return array_filter(
                 explode(',', str_replace(' ', '', $pick)),

--- a/tests/EloquentQueryModifierTest.php
+++ b/tests/EloquentQueryModifierTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Koala\Pouch\Tests;
+
+use Koala\Pouch\EloquentQueryModifier;
+
+class EloquentQueryModifierTest extends TestCase
+{
+    public function testItAssignmentOfPicksIsReflected()
+    {
+        $modifier = new EloquentQueryModifier();
+
+        $modifier->setPicks(['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $modifier->getPicks());
+
+        $modifier->setPicks([]);
+        $this->assertEquals([], $modifier->getPicks());
+
+        $modifier->addPick('foo');
+        $this->assertEquals(['foo'], $modifier->getPicks());
+
+        $modifier->addPick('');
+        $this->assertEquals(['foo'], $modifier->getPicks());
+
+        $modifier->addPick('bar');
+        $this->assertEquals(['foo', 'bar'], $modifier->getPicks());
+
+        $modifier->addPicks(['foo', 'bar', 'bar', 'bar', 'foo', 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $modifier->getPicks());
+
+        $modifier->addPicks(['foo', 'bar', 'baz', 'bar', 'foo', 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $modifier->getPicks());
+    }
+}

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Koala\Pouch\Tests;
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
 use Koala\Pouch\Contracts\AccessControl;
 use Koala\Pouch\Tests\Models\Tag;
 use Koala\Pouch\Tests\Seeds\FilterDataSeeder;
@@ -1494,6 +1495,25 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertFalse($this->getRepository(User::class, [])->isManyOperation());
         $this->assertFalse($this->getRepository(User::class, $notManyOperationData)->isManyOperation());
         $this->assertTrue($this->getRepository(User::class, $manyOperationData)->isManyOperation());
+    }
+
+    public function testItCanFindASimpleModelAndPickASubsetOfColumns()
+    {
+        $this->seedUsers();
+        $repo       = $this->getRepository(User::class);
+        $user       = $repo->findOrFail(1);
+
+        $repo->modify()->addPicks(['id', 'username']);
+
+        $userWithPicks = $repo->findOrFail(1);
+
+        $repo->modify()->setPicks([]);
+
+        $userWithMorePicks = $repo->findOrFail(1);
+
+        $this->assertEqualsCanonicalizing(Schema::getColumnListing($user->getTable()), array_keys($user->getAttributes()));
+        $this->assertEqualsCanonicalizing(['id', 'username'], array_keys($userWithPicks->getAttributes()));
+        $this->assertEqualsCanonicalizing([], array_keys($userWithMorePicks->getAttributes()));
     }
 
     public function sortDirectionProvider()

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1509,11 +1509,13 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo->modify()->addPick('occupation');
 
-        $userWithMorePicks = $repo->findOrFail(1);
+        $repo->modify()->setEagerLoads(['posts']);
+        $userWithMorePicksAndEagerLoad = $repo->findOrFail(1);
 
         $this->assertEqualsCanonicalizing(Schema::getColumnListing($user->getTable()), array_keys($user->getAttributes()));
         $this->assertEqualsCanonicalizing(['id', 'username'], array_keys($userWithPicks->getAttributes()));
-        $this->assertEqualsCanonicalizing(['id', 'username', 'occupation'], array_keys($userWithMorePicks->getAttributes()));
+        //Assert that posts have been eager loaded in addition to picked attributes
+        $this->assertEqualsCanonicalizing(['id', 'username', 'occupation', 'posts'], array_keys($userWithMorePicksAndEagerLoad->toArray()));
     }
 
     public function testItOnlyPicksASubsetOfColumnsThatExistOnTheResourceModel()

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1523,7 +1523,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertEqualsCanonicalizing(Schema::getColumnListing($user->getTable()), array_keys($user->getAttributes()));
 
         //Assert that posts have been eager loaded in addition to picked attributes
-        $this->assertArrayHasKey('posts', array_keys($userWithMorePicksAndEagerLoad->toArray()));
+        $this->assertArrayHasKey('posts', $userWithMorePicksAndEagerLoad->toArray());
         $this->assertNotEmpty($userWithMorePicksAndEagerLoad->posts);
     }
 

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -875,6 +875,7 @@ class EloquentRepositoryTest extends DBTestCase
         );
 
         $repository = $this->getRepository(User::class);
+
         $this->assertEquals($allCount = User::count(), $repository->all()->count());
 
         $repository->modify()->setFilters(['username' => '~galaxyfarfaraway.com']);
@@ -1538,7 +1539,7 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $valueToAvoid = $direction == 'desc' ? -1 : 1;
         $collection->sliding(2)->eachSpread(function ($previous, $current) use ($valueToAvoid, $direction) {
-            $word = $valueToAvoid == -1 ? 'after' : 'before';
+            $word    = $valueToAvoid == -1 ? 'after' : 'before';
             $message = "Failed asserting that the collection is sorted in $direction order. $previous does not come $word to $current.";
             $this->assertNotEquals($valueToAvoid, $previous <=> $current, $message);
         });

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1516,6 +1516,25 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertEqualsCanonicalizing([], array_keys($userWithMorePicks->getAttributes()));
     }
 
+    public function testItOnlyPicksASubsetOfColumnsThatExistOnTheResourceModel()
+    {
+        $this->seedUsers();
+        $repo       = $this->getRepository(User::class);
+        $user       = $repo->findOrFail(1);
+
+        $repo->modify()->addPicks(['id', 'username', 'not_appearing_in_this_model']);
+
+        $userWithPicks = $repo->findOrFail(1);
+
+        $repo->modify()->setPicks([]);
+
+        $userWithMorePicks = $repo->findOrFail(1);
+
+        $this->assertEqualsCanonicalizing(Schema::getColumnListing($user->getTable()), array_keys($user->getAttributes()));
+        $this->assertEqualsCanonicalizing(['id', 'username'], array_keys($userWithPicks->getAttributes()));
+        $this->assertEqualsCanonicalizing([], array_keys($userWithMorePicks->getAttributes()));
+    }
+
     public function sortDirectionProvider()
     {
         return [['asc'], ['desc']];

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1507,32 +1507,22 @@ class EloquentRepositoryTest extends DBTestCase
 
         $userWithPicks = $repo->findOrFail(1);
 
-        $repo->modify()->setPicks([]);
+        $repo->modify()->addPick('occupation');
 
         $userWithMorePicks = $repo->findOrFail(1);
 
         $this->assertEqualsCanonicalizing(Schema::getColumnListing($user->getTable()), array_keys($user->getAttributes()));
         $this->assertEqualsCanonicalizing(['id', 'username'], array_keys($userWithPicks->getAttributes()));
-        $this->assertEqualsCanonicalizing([], array_keys($userWithMorePicks->getAttributes()));
+        $this->assertEqualsCanonicalizing(['id', 'username', 'occupation'], array_keys($userWithMorePicks->getAttributes()));
     }
 
     public function testItOnlyPicksASubsetOfColumnsThatExistOnTheResourceModel()
     {
         $this->seedUsers();
-        $repo       = $this->getRepository(User::class);
-        $user       = $repo->findOrFail(1);
+        $repo = $this->getRepository(User::class);
+        $repo->modify()->setPicks(['id', 'username', 'notinthismodel']);
 
-        $repo->modify()->addPicks(['id', 'username', 'not_appearing_in_this_model']);
-
-        $userWithPicks = $repo->findOrFail(1);
-
-        $repo->modify()->setPicks([]);
-
-        $userWithMorePicks = $repo->findOrFail(1);
-
-        $this->assertEqualsCanonicalizing(Schema::getColumnListing($user->getTable()), array_keys($user->getAttributes()));
-        $this->assertEqualsCanonicalizing(['id', 'username'], array_keys($userWithPicks->getAttributes()));
-        $this->assertEqualsCanonicalizing([], array_keys($userWithMorePicks->getAttributes()));
+        $this->assertEqualsCanonicalizing(['id', 'username'], array_keys($repo->firstOrFail()->getAttributes()));
     }
 
     public function sortDirectionProvider()

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1509,16 +1509,22 @@ class EloquentRepositoryTest extends DBTestCase
         $repo->modify()->addPicks(['id', 'username']);
 
         $userWithPicks = $repo->findOrFail(1);
+        //Eloquent models that were loaded with a subset of columns will only have those attributes set
+        $this->assertEquals(['id', 'username'], array_keys($userWithPicks->getAttributes()));
+
 
         $repo->modify()->addPick('occupation');
 
         $repo->modify()->setEagerLoads(['posts']);
         $userWithMorePicksAndEagerLoad = $repo->findOrFail(1);
+        //Only picked columns yield attributes
+        $this->assertEquals(['id', 'username', 'occupation'], array_keys($userWithMorePicksAndEagerLoad->getAttributes()));
 
         $this->assertEqualsCanonicalizing(Schema::getColumnListing($user->getTable()), array_keys($user->getAttributes()));
-        $this->assertEqualsCanonicalizing(['id', 'username'], array_keys($userWithPicks->getAttributes()));
+
         //Assert that posts have been eager loaded in addition to picked attributes
-        $this->assertEqualsCanonicalizing(['id', 'username', 'occupation', 'posts'], array_keys($userWithMorePicksAndEagerLoad->toArray()));
+        $this->assertArrayHasKey('posts', array_keys($userWithMorePicksAndEagerLoad->toArray()));
+        $this->assertNotEmpty($userWithMorePicksAndEagerLoad->posts);
     }
 
     public function testItOnlyPicksASubsetOfColumnsThatExistOnTheResourceModel()

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -833,10 +833,12 @@ class EloquentRepositoryTest extends DBTestCase
         );
 
         $repository = $this->getRepository(User::class);
+
         $this->assertEquals($allCount = User::count(), $repository->all()->count());
 
         $repository->modify()->setFilters(['username' => '~galaxyfarfaraway.com']);
         $found_users = $repository->all();
+
         $this->assertEquals($allCount - 1, $found_users->count());
         $this->assertFalse($found_users->contains($otherUser));
 
@@ -1500,8 +1502,8 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItCanFindASimpleModelAndPickASubsetOfColumns()
     {
         $this->seedUsers();
-        $repo       = $this->getRepository(User::class);
-        $user       = $repo->findOrFail(1);
+        $repo = $this->getRepository(User::class);
+        $user = $repo->findOrFail(1);
 
         $repo->modify()->addPicks(['id', 'username']);
 

--- a/tests/RepositoryMiddlewareTest.php
+++ b/tests/RepositoryMiddlewareTest.php
@@ -235,6 +235,7 @@ class RepositoryMiddlewareTest extends TestCase
     public function pickAndExpectedResultProvider()
     {
         return [
+            //?pick=a,b,c
             ['a,b,c', ['a', 'b', 'c']],
             ['a ,b, c', ['a', 'b', 'c']],
             ['a ,b,', ['a', 'b']],
@@ -242,8 +243,12 @@ class RepositoryMiddlewareTest extends TestCase
             ['0,1,2', ['0', '1', '2']],
             ['0', ['0']],
             [null, []],
-            [['a', 'b'], []],
-            ['', []]
+            [['a', 'b'], ['a', 'b']],
+            ['', []],
+            //?pick[]=a&pick[]=b&pick[]=c
+            [['a', 'b', 'c'], ['a', 'b', 'c']],
+            [['0','1','2'], ['0', '1', '2']],
+            [[0, 1, 2], ['0', '1', '2']],
         ];
     }
 }

--- a/tests/RepositoryMiddlewareTest.php
+++ b/tests/RepositoryMiddlewareTest.php
@@ -221,8 +221,8 @@ class RepositoryMiddlewareTest extends TestCase
     public function testItCanAcceptPicksFromRequest($input, $expectedPicks)
     {
         $middleware = new RepositoryMiddleware();
-        $request = Request::create('/users', 'GET', ['pick' => $input]);
-        $route = new Route('GET', $request->getUri(), ['uses' => fn () => null, 'resource' => User::class]);
+        $request    = Request::create('/users', 'GET', ['pick' => $input]);
+        $route      = new Route('GET', $request->getUri(), ['uses' => fn () => null, 'resource' => User::class]);
 
         $route->bind($request);
         $request->setRouteResolver(fn () => $route);

--- a/tests/RepositoryMiddlewareTest.php
+++ b/tests/RepositoryMiddlewareTest.php
@@ -238,6 +238,7 @@ class RepositoryMiddlewareTest extends TestCase
             ['a,b,c', ['a', 'b', 'c']],
             ['a ,b, c', ['a', 'b', 'c']],
             ['a ,b,', ['a', 'b']],
+            ['a', ['a']],
             ['0,1,2', ['0', '1', '2']],
             ['0', ['0']],
             [null, []],

--- a/tests/RepositoryMiddlewareTest.php
+++ b/tests/RepositoryMiddlewareTest.php
@@ -46,6 +46,7 @@ class RepositoryMiddlewareTest extends TestCase
         $request->shouldReceive('get')->with('group')->once()->andReturn([]);
         $request->shouldReceive('get')->with('include')->once()->andReturn([]);
         $request->shouldReceive('get')->with('aggregate')->once()->andReturn([]);
+        $request->shouldReceive('get')->with('pick')->once()->andReturn([]);
 
         $middleware = new RepositoryMiddleware();
         $repository = $middleware->buildRepository($request);
@@ -72,6 +73,7 @@ class RepositoryMiddlewareTest extends TestCase
         $request->shouldReceive('get')->with('group')->once()->andReturn([]);
         $request->shouldReceive('get')->with('include')->once()->andReturn([]);
         $request->shouldReceive('get')->with('aggregate')->once()->andReturn([]);
+        $request->shouldReceive('get')->with('pick')->once()->andReturn([]);
 
         $middleware = new RepositoryMiddleware();
         $repository = $middleware->buildRepository($request);
@@ -104,6 +106,7 @@ class RepositoryMiddlewareTest extends TestCase
         $request->shouldReceive('get')->with('group')->once()->andReturn([]);
         $request->shouldReceive('get')->with('include')->once()->andReturn([]);
         $request->shouldReceive('get')->with('aggregate')->once()->andReturn([]);
+        $request->shouldReceive('get')->with('pick')->once()->andReturn([]);
 
         $middleware = new RepositoryMiddleware();
         $repository = $middleware->buildRepository($request);
@@ -146,6 +149,7 @@ class RepositoryMiddlewareTest extends TestCase
         $request->shouldReceive('get')->with('aggregate')->once()->andReturn([
             'foo' => 'aggregate',
         ]);
+        $request->shouldReceive('get')->with('pick')->once()->andReturn([]);
 
         $middleware = new RepositoryMiddleware();
         $repository = $middleware->buildRepository($request);


### PR DESCRIPTION
# What

Adds the ability to limit which fields are picked in a query

# Why

There is a demand to limit the overhead or large models and/or large lists of search results where most of the data is not needed.

# How

Adds a new query parameter to limit which fields are requested from a resource.
Ex: `GET /users?pick=id,username,occupation` will limit the amount of data fetched and returned to just three fields.

