### PR TITLE
Apply picked filter to appended and other model attributes after the query has been executed

### DIFF
--- a/src/Contracts/QueryModifier.php
+++ b/src/Contracts/QueryModifier.php
@@ -195,7 +195,7 @@ interface QueryModifier
      *
      * @return array
      */
-    public function getPicks(): ?array;
+    public function getPicks(): array;
 
     /**
      * Set picked fields

--- a/src/EloquentQueryModifier.php
+++ b/src/EloquentQueryModifier.php
@@ -675,7 +675,7 @@ class EloquentQueryModifier implements QueryModifier
         return $this->setPicks(array_merge($this->picks, $names));
     }
 
-    public function getPicks(): ?array
+    public function getPicks(): array
     {
         return $this->picks;
     }

--- a/src/EloquentRepository.php
+++ b/src/EloquentRepository.php
@@ -279,15 +279,15 @@ class EloquentRepository implements Repository
     {
         return $this->transformModelForVisibility($this->query()->findOrFail($id));
     }
-
     /**
+
      * Get all elements against the base query.
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function all(): Collection
     {
-        return $this->transformModelsForVisibility($this->query()->get());
+        return $this->query()->get()->transform(fn ($model) => $this->transformModelForVisibility($model));
     }
 
     /**
@@ -300,7 +300,7 @@ class EloquentRepository implements Repository
     {
         $paginator = $this->query()->paginate($per_page);
         //Modify attribute visibility for all models in the collection
-        $paginator->getCollection()->pipe(fn ($models) => $this->transformModelsForVisibility($models));
+        $paginator->getCollection()->transform(fn ($model) => $this->transformModelForVisibility($model));
 
         return $paginator;
     }
@@ -661,12 +661,6 @@ class EloquentRepository implements Repository
     public function firstOrFail(): Model
     {
         return $this->transformModelForVisibility($this->query()->firstOrFail());
-    }
-
-    protected function transformModelsForVisibility(Collection $models): Collection
-    {
-        //Modify collection items in place
-        return $models->transform(fn ($model) => $this->transformModelForVisibility($model));
     }
 
     protected function transformModelForVisibility(?Model $model): ?Model

--- a/src/EloquentRepository.php
+++ b/src/EloquentRepository.php
@@ -679,13 +679,12 @@ class EloquentRepository implements Repository
             return $model;
         }
 
-        $originalHidden = $model->getHidden();
-        //Move the picked and included fields into the visible set
-        $model->makeVisible($this->modify()->getPicks());
-        //Keep the original set of hidden fields hidden, even if it includes picks and includes
-        $model->makeHidden($originalHidden);
-        //Capture additional appended and with fields that were not listed in the original list of hidden fields
-        $model->makeHidden(array_diff(array_keys($model->toArray()), array_merge($this->modify()->getEagerLoads(), $this->modify()->getPicks())));
+        $visibleModelAttributeNames       = array_unique(array_merge($model->getVisible(), array_keys($model->toArray())));
+        $pickedVisibleModelAttributeNames = array_intersect(array_merge($this->modify()->getEagerLoads(), $this->modify()->getPicks()), $visibleModelAttributeNames);
+
+        //Make all fields other than picked and includes hidden
+        $model->setHidden($visibleModelAttributeNames);
+        $model->makeVisible($pickedVisibleModelAttributeNames);
 
         return $model;
     }

--- a/src/EloquentRepository.php
+++ b/src/EloquentRepository.php
@@ -77,12 +77,6 @@ class EloquentRepository implements Repository
     protected $query_filter_container;
 
     /**
-     * Array of callbacks used to transform a model after query
-     * @var array
-     */
-    protected array $model_transformer_callbacks;
-
-    /**
      * Access the access compiler
      *
      * @return \Koala\Pouch\Contracts\AccessControl

--- a/src/EloquentRepository.php
+++ b/src/EloquentRepository.php
@@ -118,11 +118,6 @@ class EloquentRepository implements Repository
         return $this->query_modifier;
     }
 
-    public function addTransformation(callable $callback)
-    {
-        $this->model_transformer_callbacks[] = $callback;
-    }
-
     /**
      * Set the QueryModifier
      *

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -304,7 +304,7 @@ class EloquentRepositoryTest extends DBTestCase
             'user'  => [
                 'username' => 'josh',
             ],
-            'tags'  => [
+            'tags' => [
                 [
                     'label' => 'Has Extra',
                     'pivot' => [
@@ -483,7 +483,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertNull($user->not_fillable);
 
         $input['id'] = $user->id;
-        $user = $this->getRepository(User::class, $input)->update();
+        $user        = $this->getRepository(User::class, $input)->update();
         $this->assertNull($user->not_fillable);
     }
 
@@ -531,7 +531,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertNull($user->profile->not_fillable);
 
         $input['id'] = $user->id;
-        $user = $this->getRepository(User::class, $input)->update();
+        $user        = $this->getRepository(User::class, $input)->update();
         $this->assertNull($user->not_fillable);
         $this->assertNull($user->profile->not_fillable);
     }
@@ -551,7 +551,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertNotNull($user);
 
         $input['delete'] = 'doesn\'t matter but this should not be run';
-        $input['id'] = $user->id;
+        $input['id']     = $user->id;
 
         // Since users are soft deletable, if this fails and we run a $user->delete(), magic box will delete the record
         // but then try to recreate it with the same ID and get a MySQL unique constraint error because the
@@ -913,7 +913,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repository->accessControl()->addFillable('foo');
 
-        $expect = User::FILLABLE;
+        $expect   = User::FILLABLE;
         $expect[] = 'foo';
 
         $this->assertSame($expect, $repository->accessControl()->getFillable());
@@ -927,7 +927,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repository->accessControl()->addManyFillable(['foo', 'bar', 'baz']);
 
-        $expect = User::FILLABLE;
+        $expect   = User::FILLABLE;
         $expect[] = 'foo';
         $expect[] = 'bar';
         $expect[] = 'baz';
@@ -1239,22 +1239,22 @@ class EloquentRepositoryTest extends DBTestCase
         $post = $this->getRepository(
             Post::class,
             [
-                'title' => 'All the Tags',
+                'title'        => 'All the Tags',
                 'not_fillable' => 'should not be set',
-                'user' => [
-                    'username' => 'simon',
+                'user'         => [
+                    'username'     => 'simon',
                     'not_fillable' => 'should not be set',
-                    'profile' => [
+                    'profile'      => [
                         'favorite_cheese' => 'brie',
                     ],
                 ],
                 'tags' => [
                     [
-                        'label' => 'Important Stuff',
+                        'label'        => 'Important Stuff',
                         'not_fillable' => 'should not be set',
                     ],
                     [
-                        'label' => 'Less Important Stuff',
+                        'label'        => 'Less Important Stuff',
                         'not_fillable' => 'should not be set',
                     ],
                 ],
@@ -1277,7 +1277,7 @@ class EloquentRepositoryTest extends DBTestCase
             User::class,
             [
                 'username' => 'joe',
-                'posts' => [
+                'posts'    => [
                     [
                         'title' => 'Some Great Post',
                     ],
@@ -1316,7 +1316,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertEquals(User::count(), $repository->all()->count());
 
         $repository->modify()->setFilters([
-            'not_filterable' => '=foo', // Should not be applied
+            'not_filterable'       => '=foo', // Should not be applied
             'posts.not_filterable' => '=foo', // Should not be applied
         ]);
         $found_users = $repository->all();
@@ -1334,7 +1334,7 @@ class EloquentRepositoryTest extends DBTestCase
         $repository->accessControl()->setFilterable([]);
         $repository->modify()->setFilters([
             'profile.is_human' => '=true',
-            'times_captured' => '>2'
+            'times_captured'   => '>2'
         ]);
         $found_users = $repository->all();
 
@@ -1344,7 +1344,7 @@ class EloquentRepositoryTest extends DBTestCase
         $repository->accessControl()->setFilterable(AccessControl::ALLOW_ALL);
         $repository->modify()->setFilters([
             'profile.is_human' => '=true',
-            'times_captured' => '>2'
+            'times_captured'   => '>2'
         ]);
         $found_users = $repository->all();
 
@@ -1493,7 +1493,7 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItCanCheckIfManyOperation()
     {
         $notManyOperationData = ['id' => 1, 'username' => 'bobby'];
-        $manyOperationData = [['id' => 1, 'username' => 'bobby'], ['id' => 2, 'username' => 'sam']];
+        $manyOperationData    = [['id' => 1, 'username' => 'bobby'], ['id' => 2, 'username' => 'sam']];
 
         $this->assertFalse($this->getRepository(User::class, [])->isManyOperation());
         $this->assertFalse($this->getRepository(User::class, $notManyOperationData)->isManyOperation());

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Koala\Pouch\Tests;
 
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schema;
 use Koala\Pouch\Contracts\AccessControl;
@@ -62,8 +61,8 @@ class EloquentRepositoryTest extends DBTestCase
 
     public function testItCanFindASimpleModel()
     {
-        $repo = $this->getRepository(User::class);
-        $user = $repo->save();
+        $repo       = $this->getRepository(User::class);
+        $user       = $repo->save();
         $found_user = $repo->find($user->id);
         $this->assertNotNull($found_user);
         $this->assertEquals($user->id, $found_user->id);
@@ -72,9 +71,9 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItCanReturnASingleModelFromAQuery()
     {
         $this->seedUsers();
-        $repo = $this->getRepository(User::class);
-        $users = $repo->all();
-        $firstUser = $repo->first();
+        $repo            = $this->getRepository(User::class);
+        $users           = $repo->all();
+        $firstUser       = $repo->first();
         $firstOrFailUser = $repo->firstOrFail();
         $this->assertNotNull($firstUser);
         $this->assertNotNull($firstOrFailUser);
@@ -85,7 +84,7 @@ class EloquentRepositoryTest extends DBTestCase
 
     public function testItFirstReturnsNullWhenTheQueryHasNoResults()
     {
-        $model = new class () extends User {
+        $model = new class() extends User {
             public static function query()
             {
                 return \Mockery::mock(parent::query())
@@ -100,7 +99,7 @@ class EloquentRepositoryTest extends DBTestCase
 
     public function testItFailsWhenFirstOrFailQueryHasNoResults()
     {
-        $model = new class () extends User {
+        $model = new class() extends User {
             public static function query()
             {
                 return \Mockery::mock(parent::query())
@@ -124,8 +123,8 @@ class EloquentRepositoryTest extends DBTestCase
 
     public function testItPaginates()
     {
-        $repository = $this->getRepository(User::class);
-        $first_user = $repository->setInput(['username' => 'bob'])->save();
+        $repository  = $this->getRepository(User::class);
+        $first_user  = $repository->setInput(['username' => 'bob'])->save();
         $second_user = $repository->setInput(['username' => 'sue'])->save();
 
         $paginator = $repository->paginate(1);
@@ -137,7 +136,7 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $this->getRepository(User::class, [
             'username' => 'joe',
-            'posts' => [
+            'posts'    => [
                 [
                     'title' => 'Some Great Post',
                 ],
@@ -173,7 +172,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertEquals($user->username, 'bobby');
 
         $user = $this->getRepository(User::class, [
-            'id' => 1,
+            'id'       => 1,
             'username' => 'sue'
         ])->save();
         $this->assertEquals($user->id, 1);
@@ -194,7 +193,7 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $post = $this->getRepository(Post::class, [
             'title' => 'Some Great Post',
-            'user' => [
+            'user'  => [
                 'username' => 'jimmy',
             ],
         ])->save();
@@ -207,7 +206,7 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $user = $this->getRepository(User::class, [
             'username' => 'joe',
-            'posts' => [
+            'posts'    => [
                 [
                     'title' => 'Some Great Post',
                 ],
@@ -228,7 +227,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertEquals($post->title, 'Yet Another Great Post');
 
         $this->getRepository(User::class, [
-            'id' => $user->id,
+            'id'    => $user->id,
             'posts' => [
                 [
                     'id' => 1,
@@ -250,7 +249,7 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $user = $this->getRepository(User::class, [
             'username' => 'joe',
-            'profile' => [
+            'profile'  => [
                 'favorite_cheese' => 'brie',
             ],
         ])->save();
@@ -260,7 +259,7 @@ class EloquentRepositoryTest extends DBTestCase
         $old_profile_id = $user->profile->id;
 
         $user = $this->getRepository(User::class, [
-            'id' => $user->id,
+            'id'      => $user->id,
             'profile' => [
                 'favorite_cheese' => 'pepper jack',
             ],
@@ -277,9 +276,9 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $post = $this->getRepository(Post::class, [
             'title' => 'All the Tags',
-            'user' => [
+            'user'  => [
                 'username' => 'simon',
-                'profile' => [
+                'profile'  => [
                     'favorite_cheese' => 'brie',
                 ],
             ],
@@ -302,10 +301,10 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $post = $this->getRepository(Post::class, [
             'title' => 'All the Tags',
-            'user' => [
+            'user'  => [
                 'username' => 'josh',
             ],
-            'tags' => [
+            'tags'  => [
                 [
                     'label' => 'Has Extra',
                     'pivot' => [
@@ -319,10 +318,10 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertEquals($tag->pivot->extra, 'Meowth');
 
         $post = $this->getRepository(Post::class, [
-            'id' => $post->id,
+            'id'   => $post->id,
             'tags' => [
                 [
-                    'id' => $tag->id,
+                    'id'    => $tag->id,
                     'pivot' => [
                         'extra' => 'Pikachu',
                     ],
@@ -360,10 +359,10 @@ class EloquentRepositoryTest extends DBTestCase
         $repository = $this->getRepository(User::class);
         $first_user = $repository->setInput([
             'username' => 'Bobby',
-            'posts' => [
+            'posts'    => [
                 [
                     'title' => 'First Post',
-                    'tags' => [
+                    'tags'  => [
                         ['label' => 'Tag1']
                     ]
                 ]
@@ -371,10 +370,10 @@ class EloquentRepositoryTest extends DBTestCase
         ])->save();
         $second_user = $repository->setInput([
             'username' => 'Robby',
-            'posts' => [
+            'posts'    => [
                 [
                     'title' => 'Zis is the final post alphabetically',
-                    'tags' => [
+                    'tags'  => [
                         ['label' => 'Tag2']
                     ]
                 ]
@@ -382,10 +381,10 @@ class EloquentRepositoryTest extends DBTestCase
         ])->save();
         $third_user = $repository->setInput([
             'username' => 'Gobby',
-            'posts' => [
+            'posts'    => [
                 [
                     'title' => 'Third Post',
-                    'tags' => [
+                    'tags'  => [
                         ['label' => 'Tag3']
                     ]
                 ]
@@ -447,16 +446,16 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItOnlyUpdatesFillableAttributesOnCreate()
     {
         $input = [
-            'username' => 'javacup@galaxyfarfaraway.com',
-            'name' => 'Jabba The Hutt',
-            'hands' => 10,
+            'username'       => 'javacup@galaxyfarfaraway.com',
+            'name'           => 'Jabba The Hutt',
+            'hands'          => 10,
             'times_captured' => 0,
-            'not_fillable' => 'should be null',
-            'occupation' => 'Being Gross',
-            'profile' => [
+            'not_fillable'   => 'should be null',
+            'occupation'     => 'Being Gross',
+            'profile'        => [
                 'favorite_cheese' => 'Cheddar',
-                'favorite_fruit' => 'Apples',
-                'is_human' => false
+                'favorite_fruit'  => 'Apples',
+                'is_human'        => false
             ],
         ];
 
@@ -467,16 +466,16 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItOnlyUpdatesFillableAttributesOnUpdate()
     {
         $input = [
-            'username' => 'javacup@galaxyfarfaraway.com',
-            'name' => 'Jabba The Hutt',
-            'hands' => 10,
+            'username'       => 'javacup@galaxyfarfaraway.com',
+            'name'           => 'Jabba The Hutt',
+            'hands'          => 10,
             'times_captured' => 0,
-            'not_fillable' => 'should be null',
-            'occupation' => 'Being Gross',
-            'profile' => [
+            'not_fillable'   => 'should be null',
+            'occupation'     => 'Being Gross',
+            'profile'        => [
                 'favorite_cheese' => 'Cheddar',
-                'favorite_fruit' => 'Apples',
-                'is_human' => false
+                'favorite_fruit'  => 'Apples',
+                'is_human'        => false
             ],
         ];
 
@@ -491,17 +490,17 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItOnlyUpdatesFillableAttributesForRelationsOnCreate()
     {
         $input = [
-            'username' => 'javacup@galaxyfarfaraway.com',
-            'name' => 'Jabba The Hutt',
-            'hands' => 10,
+            'username'       => 'javacup@galaxyfarfaraway.com',
+            'name'           => 'Jabba The Hutt',
+            'hands'          => 10,
             'times_captured' => 0,
-            'not_fillable' => 'should be null',
-            'occupation' => 'Being Gross',
-            'profile' => [
+            'not_fillable'   => 'should be null',
+            'occupation'     => 'Being Gross',
+            'profile'        => [
                 'favorite_cheese' => 'Cheddar',
-                'favorite_fruit' => 'Apples',
-                'is_human' => false,
-                'not_fillable' => 'should be null'
+                'favorite_fruit'  => 'Apples',
+                'is_human'        => false,
+                'not_fillable'    => 'should be null'
             ],
         ];
 
@@ -513,17 +512,17 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItOnlyUpdatesFillableAttributesForRelationsOnUpdate()
     {
         $input = [
-            'username' => 'javacup@galaxyfarfaraway.com',
-            'name' => 'Jabba The Hutt',
-            'hands' => 10,
+            'username'       => 'javacup@galaxyfarfaraway.com',
+            'name'           => 'Jabba The Hutt',
+            'hands'          => 10,
             'times_captured' => 0,
-            'not_fillable' => 'should be null',
-            'occupation' => 'Being Gross',
-            'profile' => [
+            'not_fillable'   => 'should be null',
+            'occupation'     => 'Being Gross',
+            'profile'        => [
                 'favorite_cheese' => 'Cheddar',
-                'favorite_fruit' => 'Apples',
-                'is_human' => false,
-                'not_fillable' => 'should be null'
+                'favorite_fruit'  => 'Apples',
+                'is_human'        => false,
+                'not_fillable'    => 'should be null'
             ],
         ];
 
@@ -540,12 +539,12 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItDoesNotRunArbitraryMethodsOnActualInstance()
     {
         $input = [
-            'username' => 'javacup@galaxyfarfaraway.com',
-            'name' => 'Jabba The Hutt',
-            'hands' => 10,
+            'username'       => 'javacup@galaxyfarfaraway.com',
+            'name'           => 'Jabba The Hutt',
+            'hands'          => 10,
             'times_captured' => 0,
-            'not_fillable' => 'should be null',
-            'occupation' => 'Being Gross',
+            'not_fillable'   => 'should be null',
+            'occupation'     => 'Being Gross',
         ];
 
         $user = $this->getRepository(User::class, $input)->save();
@@ -568,12 +567,12 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItCanSetDepthRestriction()
     {
         $input = [
-            'username' => 'javacup@galaxyfarfaraway.com',
-            'name' => 'Jabba The Hutt',
-            'hands' => 10,
+            'username'       => 'javacup@galaxyfarfaraway.com',
+            'name'           => 'Jabba The Hutt',
+            'hands'          => 10,
             'times_captured' => 0,
-            'not_fillable' => 'should be null',
-            'occupation' => 'Being Gross',
+            'not_fillable'   => 'should be null',
+            'occupation'     => 'Being Gross',
         ];
 
         $repository = $this->getRepository(User::class, $input);
@@ -791,7 +790,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertCount(Tag::count(), $tags->pluck('label')->unique());
 
         $tags->each(
-            fn($tag) => $this->assertCollectionIsSorted($tag->posts->pluck('title'), $direction)
+            fn ($tag) => $this->assertCollectionIsSorted($tag->posts->pluck('title'), $direction)
         );
     }
 
@@ -814,7 +813,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertCount(Tag::count(), $tags->pluck('label')->unique());
 
         $tags->each(
-            fn($tag) => $this->assertCollectionIsSorted($tag->posts->pluck('title'), $direction)
+            fn ($tag) => $this->assertCollectionIsSorted($tag->posts->pluck('title'), $direction)
         );
     }
 
@@ -825,11 +824,11 @@ class EloquentRepositoryTest extends DBTestCase
         $otherUser = User::firstOrCreate(
             ['username' => 'bobbytables@xkcd.com'],
             [
-                'username' => 'bobbytables@xkcd.com',
-                'name' => 'Bobby',
-                'hands' => 2,
+                'username'       => 'bobbytables@xkcd.com',
+                'name'           => 'Bobby',
+                'hands'          => 2,
                 'times_captured' => 0,
-                'occupation' => 'Student'
+                'occupation'     => 'Student'
             ]
         );
 
@@ -845,7 +844,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $additional_filters = [
             'profile.is_human' => '=true',
-            'times_captured' => '>2'
+            'times_captured'   => '>2'
         ];
 
         $repository->modify()->addFilters($additional_filters);
@@ -854,9 +853,9 @@ class EloquentRepositoryTest extends DBTestCase
 
         $filters = $repository->modify()->getFilters();
         $this->assertEquals([
-            'username' => '~galaxyfarfaraway.com',
+            'username'         => '~galaxyfarfaraway.com',
             'profile.is_human' => '=true',
-            'times_captured' => '>2'
+            'times_captured'   => '>2'
         ], $filters);
     }
 
@@ -867,11 +866,11 @@ class EloquentRepositoryTest extends DBTestCase
         $otherUser = User::firstOrCreate(
             ['username' => 'bobbytables@xkcd.com'],
             [
-                'username' => 'bobbytables@xkcd.com',
-                'name' => 'Bobby',
-                'hands' => 2,
+                'username'       => 'bobbytables@xkcd.com',
+                'name'           => 'Bobby',
+                'hands'          => 2,
                 'times_captured' => 0,
-                'occupation' => 'Student'
+                'occupation'     => 'Student'
             ]
         );
 
@@ -890,7 +889,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $filters = $repository->modify()->getFilters();
         $this->assertEquals([
-            'username' => '~galaxyfarfaraway.com',
+            'username'         => '~galaxyfarfaraway.com',
             'profile.is_human' => '=true',
         ], $filters);
     }
@@ -979,7 +978,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repository->accessControl()->removeManyFillable(['baz', 'bag']);
 
-        $this->assertSame(['foo',], $repository->accessControl()->getFillable());
+        $this->assertSame(['foo'], $repository->accessControl()->getFillable());
     }
 
     public function testItCanDetermineIfIsFillable()
@@ -1534,7 +1533,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo = $this->getRepository(
             get_class(
-                new class () extends User {
+                new class() extends User {
                     protected $visible = [
                         'id',
                         'username',
@@ -1596,7 +1595,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo = $this->getRepository(
             get_class(
-                new class () extends User {
+                new class() extends User {
                     protected $visible = [
                         'id',
                         'username',
@@ -1641,18 +1640,18 @@ class EloquentRepositoryTest extends DBTestCase
         $repo->modify()->addPicks(['id', 'username', 'foobar', 'barbaz']);
 
         $usersWithPicks = $repo->all();
-        $this->assertTrue($usersWithPicks->every(fn($userWithPicks) => ['id', 'username', 'foobar', 'barbaz'] === array_keys($userWithPicks->toArray())));
+        $this->assertTrue($usersWithPicks->every(fn ($userWithPicks) => ['id', 'username', 'foobar', 'barbaz'] === array_keys($userWithPicks->toArray())));
 
         $repo->modify()->setPicks(['id', 'username']);
         $usersWithPicks = $repo->all();
-        $this->assertTrue($usersWithPicks->every(fn($userWithPicks) => ['id', 'username'] === array_keys($userWithPicks->toArray())));
+        $this->assertTrue($usersWithPicks->every(fn ($userWithPicks) => ['id', 'username'] === array_keys($userWithPicks->toArray())));
 
         $repo->modify()->setPicks(['id', 'username', 'stay_hidden', 'yarderp']);
         $usersWithPicks = $repo->all();
-        $this->assertTrue($usersWithPicks->every(fn($userWithPicks) => ['id', 'username', 'yarderp'] === array_keys($userWithPicks->toArray())));
+        $this->assertTrue($usersWithPicks->every(fn ($userWithPicks) => ['id', 'username', 'yarderp'] === array_keys($userWithPicks->toArray())));
 
         $paginatedUsersWithPicks = $repo->paginate(10);
-        $this->assertTrue($paginatedUsersWithPicks->getCollection()->every(fn($userWithPicks) => ['id', 'username', 'yarderp'] === array_keys($userWithPicks->toArray())));
+        $this->assertTrue($paginatedUsersWithPicks->getCollection()->every(fn ($userWithPicks) => ['id', 'username', 'yarderp'] === array_keys($userWithPicks->toArray())));
     }
 
     public function testItShowsAllVisibleFieldsWhenNoPicksAreApplied()
@@ -1661,7 +1660,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo = $this->getRepository(
             get_class(
-                new class () extends User {
+                new class() extends User {
                     protected $visible = [
                         'id',
                         'username',
@@ -1721,7 +1720,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo->modify()->setEagerLoads(['profile']);
         $usersWithPicks = Collection::wrap([$repo->firstOrFail(), $repo->first(), $repo->find(1), $repo->findOrFail(1)])->concat($repo->all());
-        $usersWithPicks->each(fn($userWithPicks) => $this->assertEqualsCanonicalizing(array_diff($userWithPicks->getVisible(), array_keys($userWithPicks->toArray())), ['posts']));
+        $usersWithPicks->each(fn ($userWithPicks) => $this->assertEqualsCanonicalizing(array_diff($userWithPicks->getVisible(), array_keys($userWithPicks->toArray())), ['posts']));
     }
 
 

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -23,13 +23,13 @@ class EloquentRepositoryTest extends DBTestCase
      * Retrieve a sample repository for testing.
      *
      * @param string|null $model_class
-     * @param array       $input
+     * @param array $input
      *
      * @return \Koala\Pouch\Contracts\Repository|\Koala\Pouch\EloquentRepository
      */
     private function getRepository($model_class = null, array $input = [])
     {
-        if (! is_null($model_class)) {
+        if (!is_null($model_class)) {
             $repository = (new EloquentRepository())->setModelClass($model_class)->setInput($input);
             $repository->accessControl()->setDepthRestriction(3);
 
@@ -62,8 +62,8 @@ class EloquentRepositoryTest extends DBTestCase
 
     public function testItCanFindASimpleModel()
     {
-        $repo       = $this->getRepository(User::class);
-        $user       = $repo->save();
+        $repo = $this->getRepository(User::class);
+        $user = $repo->save();
         $found_user = $repo->find($user->id);
         $this->assertNotNull($found_user);
         $this->assertEquals($user->id, $found_user->id);
@@ -72,9 +72,9 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItCanReturnASingleModelFromAQuery()
     {
         $this->seedUsers();
-        $repo            = $this->getRepository(User::class);
-        $users           = $repo->all();
-        $firstUser       = $repo->first();
+        $repo = $this->getRepository(User::class);
+        $users = $repo->all();
+        $firstUser = $repo->first();
         $firstOrFailUser = $repo->firstOrFail();
         $this->assertNotNull($firstUser);
         $this->assertNotNull($firstOrFailUser);
@@ -124,8 +124,8 @@ class EloquentRepositoryTest extends DBTestCase
 
     public function testItPaginates()
     {
-        $repository  = $this->getRepository(User::class);
-        $first_user  = $repository->setInput(['username' => 'bob'])->save();
+        $repository = $this->getRepository(User::class);
+        $first_user = $repository->setInput(['username' => 'bob'])->save();
         $second_user = $repository->setInput(['username' => 'sue'])->save();
 
         $paginator = $repository->paginate(1);
@@ -136,21 +136,21 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItEagerLoadsRelationsSafely()
     {
         $this->getRepository(User::class, [
-                'username' => 'joe',
-                'posts'    => [
-                    [
-                        'title' => 'Some Great Post',
-                    ],
-                ]
-            ])->save();
+            'username' => 'joe',
+            'posts' => [
+                [
+                    'title' => 'Some Great Post',
+                ],
+            ]
+        ])->save();
 
         $repository = $this->getRepository(User::class);
         $repository->modify()
             ->setFilters(['username' => 'joe'])
             ->setEagerLoads([
-                    'posts.nothing',
-                    'nada'
-                ]);
+                'posts.nothing',
+                'nada'
+            ]);
         $user = $repository->all()->first();
 
 
@@ -173,9 +173,9 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertEquals($user->username, 'bobby');
 
         $user = $this->getRepository(User::class, [
-                'id'       => 1,
-                'username' => 'sue'
-            ])->save();
+            'id' => 1,
+            'username' => 'sue'
+        ])->save();
         $this->assertEquals($user->id, 1);
         $this->assertEquals($user->username, 'sue');
     }
@@ -193,11 +193,11 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItFillsBelongsToRelations()
     {
         $post = $this->getRepository(Post::class, [
-                'title' => 'Some Great Post',
-                'user'  => [
-                    'username' => 'jimmy',
-                ],
-            ])->save();
+            'title' => 'Some Great Post',
+            'user' => [
+                'username' => 'jimmy',
+            ],
+        ])->save();
 
         $this->assertNotNull($post->user);
         $this->assertEquals($post->user->username, 'jimmy');
@@ -206,21 +206,21 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItFillsHasManyRelations()
     {
         $user = $this->getRepository(User::class, [
-                'username' => 'joe',
-                'posts'    => [
-                    [
-                        'title' => 'Some Great Post',
-                    ],
-                    [
-                        'title' => 'Yet Another Great Post',
-                    ],
-                ]
-            ])->save();
+            'username' => 'joe',
+            'posts' => [
+                [
+                    'title' => 'Some Great Post',
+                ],
+                [
+                    'title' => 'Yet Another Great Post',
+                ],
+            ]
+        ])->save();
 
         $this->assertEquals($user->posts->pluck('id')->toArray(), [
-                1,
-                2
-            ]);
+            1,
+            2
+        ]);
 
         $post = Post::find(2);
         $this->assertNotNull($post);
@@ -228,19 +228,19 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertEquals($post->title, 'Yet Another Great Post');
 
         $this->getRepository(User::class, [
-                'id'    => $user->id,
-                'posts' => [
-                    [
-                        'id' => 1,
-                    ],
+            'id' => $user->id,
+            'posts' => [
+                [
+                    'id' => 1,
                 ],
-            ])->save();
+            ],
+        ])->save();
 
         $user->load('posts');
 
         $this->assertEquals($user->posts->pluck('id')->toArray(), [
-                1,
-            ]);
+            1,
+        ]);
 
         $post = Post::find(2);
         $this->assertNull($post);
@@ -249,22 +249,22 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItFillsHasOneRelations()
     {
         $user = $this->getRepository(User::class, [
-                'username' => 'joe',
-                'profile'  => [
-                    'favorite_cheese' => 'brie',
-                ],
-            ])->save();
+            'username' => 'joe',
+            'profile' => [
+                'favorite_cheese' => 'brie',
+            ],
+        ])->save();
 
         $this->assertNotNull($user->profile);
         $this->assertEquals($user->profile->favorite_cheese, 'brie');
         $old_profile_id = $user->profile->id;
 
         $user = $this->getRepository(User::class, [
-                'id'      => $user->id,
-                'profile' => [
-                    'favorite_cheese' => 'pepper jack',
-                ],
-            ])->save();
+            'id' => $user->id,
+            'profile' => [
+                'favorite_cheese' => 'pepper jack',
+            ],
+        ])->save();
 
         $this->assertNotNull($user->profile);
         $this->assertEquals($user->profile->favorite_cheese, 'pepper jack');
@@ -276,22 +276,22 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItCascadesThroughSupportedRelations()
     {
         $post = $this->getRepository(Post::class, [
-                'title' => 'All the Tags',
-                'user'  => [
-                    'username' => 'simon',
-                    'profile'  => [
-                        'favorite_cheese' => 'brie',
-                    ],
+            'title' => 'All the Tags',
+            'user' => [
+                'username' => 'simon',
+                'profile' => [
+                    'favorite_cheese' => 'brie',
                 ],
-                'tags' => [
-                    [
-                        'label' => 'Important Stuff',
-                    ],
-                    [
-                        'label' => 'Less Important Stuff',
-                    ],
+            ],
+            'tags' => [
+                [
+                    'label' => 'Important Stuff',
                 ],
-            ])->save();
+                [
+                    'label' => 'Less Important Stuff',
+                ],
+            ],
+        ])->save();
 
         $this->assertEquals($post->tags()->count(), 2);
         $this->assertNotNull($post->user->profile);
@@ -301,34 +301,34 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItUpdatesBelongsToManyPivots()
     {
         $post = $this->getRepository(Post::class, [
-                'title' => 'All the Tags',
-                'user'  => [
-                    'username' => 'josh',
-                ],
-                'tags' => [
-                    [
-                        'label' => 'Has Extra',
-                        'pivot' => [
-                            'extra' => 'Meowth'
-                        ],
+            'title' => 'All the Tags',
+            'user' => [
+                'username' => 'josh',
+            ],
+            'tags' => [
+                [
+                    'label' => 'Has Extra',
+                    'pivot' => [
+                        'extra' => 'Meowth'
                     ],
                 ],
-            ])->save();
+            ],
+        ])->save();
 
         $tag = $post->tags->first();
         $this->assertEquals($tag->pivot->extra, 'Meowth');
 
         $post = $this->getRepository(Post::class, [
-                'id'   => $post->id,
-                'tags' => [
-                    [
-                        'id'    => $tag->id,
-                        'pivot' => [
-                            'extra' => 'Pikachu',
-                        ],
+            'id' => $post->id,
+            'tags' => [
+                [
+                    'id' => $tag->id,
+                    'pivot' => [
+                        'extra' => 'Pikachu',
                     ],
                 ],
-            ])->save();
+            ],
+        ])->save();
 
         $tag = $post->tags->first();
         $this->assertEquals($tag->pivot->extra, 'Pikachu');
@@ -338,16 +338,16 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $repository = $this->getRepository(User::class);
         $first_user = $repository->setInput([
-                'username' => 'Bobby'
-            ])->save();
+            'username' => 'Bobby'
+        ])->save();
         $second_user = $repository->setInput([
-                'username' => 'Robby'
-            ])->save();
+            'username' => 'Robby'
+        ])->save();
         $this->assertEquals($repository->all()->count(), 2);
 
         $repository->modify()->setSortOrder([
-                'id' => 'desc'
-            ]);
+            'id' => 'desc'
+        ]);
 
         $found_users = $repository->all();
 
@@ -359,43 +359,43 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $repository = $this->getRepository(User::class);
         $first_user = $repository->setInput([
-                'username' => 'Bobby',
-                'posts'    => [
-                    [
-                        'title' => 'First Post',
-                        'tags'  => [
-                            ['label' => 'Tag1']
-                        ]
+            'username' => 'Bobby',
+            'posts' => [
+                [
+                    'title' => 'First Post',
+                    'tags' => [
+                        ['label' => 'Tag1']
                     ]
                 ]
-            ])->save();
+            ]
+        ])->save();
         $second_user = $repository->setInput([
-                'username' => 'Robby',
-                'posts'    => [
-                    [
-                        'title' => 'Zis is the final post alphabetically',
-                        'tags'  => [
-                            ['label' => 'Tag2']
-                        ]
+            'username' => 'Robby',
+            'posts' => [
+                [
+                    'title' => 'Zis is the final post alphabetically',
+                    'tags' => [
+                        ['label' => 'Tag2']
                     ]
                 ]
-            ])->save();
+            ]
+        ])->save();
         $third_user = $repository->setInput([
-                'username' => 'Gobby',
-                'posts'    => [
-                    [
-                        'title' => 'Third Post',
-                        'tags'  => [
-                            ['label' => 'Tag3']
-                        ]
+            'username' => 'Gobby',
+            'posts' => [
+                [
+                    'title' => 'Third Post',
+                    'tags' => [
+                        ['label' => 'Tag3']
                     ]
                 ]
-            ])->save();
+            ]
+        ])->save();
         $this->assertEquals($repository->all()->count(), 3);
 
         $repository->modify()->setSortOrder([
-                'posts.title' => 'desc'
-            ]);
+            'posts.title' => 'desc'
+        ]);
 
         $found_users = $repository->all();
 
@@ -409,10 +409,10 @@ class EloquentRepositoryTest extends DBTestCase
         $repository->save();
         $this->assertEquals($repository->count(), 1);
         $repository->modify()->set([
-                function (Builder $query) {
-                    $query->whereRaw(DB::raw('0 = 1'));
-                }
-            ]);
+            function (Builder $query) {
+                $query->whereRaw(DB::raw('0 = 1'));
+            }
+        ]);
         $this->assertEquals($repository->count(), 0);
     }
 
@@ -447,16 +447,16 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItOnlyUpdatesFillableAttributesOnCreate()
     {
         $input = [
-            'username'       => 'javacup@galaxyfarfaraway.com',
-            'name'           => 'Jabba The Hutt',
-            'hands'          => 10,
+            'username' => 'javacup@galaxyfarfaraway.com',
+            'name' => 'Jabba The Hutt',
+            'hands' => 10,
             'times_captured' => 0,
-            'not_fillable'   => 'should be null',
-            'occupation'     => 'Being Gross',
-            'profile'        => [
+            'not_fillable' => 'should be null',
+            'occupation' => 'Being Gross',
+            'profile' => [
                 'favorite_cheese' => 'Cheddar',
-                'favorite_fruit'  => 'Apples',
-                'is_human'        => false
+                'favorite_fruit' => 'Apples',
+                'is_human' => false
             ],
         ];
 
@@ -467,16 +467,16 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItOnlyUpdatesFillableAttributesOnUpdate()
     {
         $input = [
-            'username'       => 'javacup@galaxyfarfaraway.com',
-            'name'           => 'Jabba The Hutt',
-            'hands'          => 10,
+            'username' => 'javacup@galaxyfarfaraway.com',
+            'name' => 'Jabba The Hutt',
+            'hands' => 10,
             'times_captured' => 0,
-            'not_fillable'   => 'should be null',
-            'occupation'     => 'Being Gross',
-            'profile'        => [
+            'not_fillable' => 'should be null',
+            'occupation' => 'Being Gross',
+            'profile' => [
                 'favorite_cheese' => 'Cheddar',
-                'favorite_fruit'  => 'Apples',
-                'is_human'        => false
+                'favorite_fruit' => 'Apples',
+                'is_human' => false
             ],
         ];
 
@@ -484,24 +484,24 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertNull($user->not_fillable);
 
         $input['id'] = $user->id;
-        $user        = $this->getRepository(User::class, $input)->update();
+        $user = $this->getRepository(User::class, $input)->update();
         $this->assertNull($user->not_fillable);
     }
 
     public function testItOnlyUpdatesFillableAttributesForRelationsOnCreate()
     {
         $input = [
-            'username'       => 'javacup@galaxyfarfaraway.com',
-            'name'           => 'Jabba The Hutt',
-            'hands'          => 10,
+            'username' => 'javacup@galaxyfarfaraway.com',
+            'name' => 'Jabba The Hutt',
+            'hands' => 10,
             'times_captured' => 0,
-            'not_fillable'   => 'should be null',
-            'occupation'     => 'Being Gross',
-            'profile'        => [
+            'not_fillable' => 'should be null',
+            'occupation' => 'Being Gross',
+            'profile' => [
                 'favorite_cheese' => 'Cheddar',
-                'favorite_fruit'  => 'Apples',
-                'is_human'        => false,
-                'not_fillable'    => 'should be null'
+                'favorite_fruit' => 'Apples',
+                'is_human' => false,
+                'not_fillable' => 'should be null'
             ],
         ];
 
@@ -513,17 +513,17 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItOnlyUpdatesFillableAttributesForRelationsOnUpdate()
     {
         $input = [
-            'username'       => 'javacup@galaxyfarfaraway.com',
-            'name'           => 'Jabba The Hutt',
-            'hands'          => 10,
+            'username' => 'javacup@galaxyfarfaraway.com',
+            'name' => 'Jabba The Hutt',
+            'hands' => 10,
             'times_captured' => 0,
-            'not_fillable'   => 'should be null',
-            'occupation'     => 'Being Gross',
-            'profile'        => [
+            'not_fillable' => 'should be null',
+            'occupation' => 'Being Gross',
+            'profile' => [
                 'favorite_cheese' => 'Cheddar',
-                'favorite_fruit'  => 'Apples',
-                'is_human'        => false,
-                'not_fillable'    => 'should be null'
+                'favorite_fruit' => 'Apples',
+                'is_human' => false,
+                'not_fillable' => 'should be null'
             ],
         ];
 
@@ -532,7 +532,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertNull($user->profile->not_fillable);
 
         $input['id'] = $user->id;
-        $user        = $this->getRepository(User::class, $input)->update();
+        $user = $this->getRepository(User::class, $input)->update();
         $this->assertNull($user->not_fillable);
         $this->assertNull($user->profile->not_fillable);
     }
@@ -540,19 +540,19 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItDoesNotRunArbitraryMethodsOnActualInstance()
     {
         $input = [
-            'username'       => 'javacup@galaxyfarfaraway.com',
-            'name'           => 'Jabba The Hutt',
-            'hands'          => 10,
+            'username' => 'javacup@galaxyfarfaraway.com',
+            'name' => 'Jabba The Hutt',
+            'hands' => 10,
             'times_captured' => 0,
-            'not_fillable'   => 'should be null',
-            'occupation'     => 'Being Gross',
+            'not_fillable' => 'should be null',
+            'occupation' => 'Being Gross',
         ];
 
         $user = $this->getRepository(User::class, $input)->save();
         $this->assertNotNull($user);
 
         $input['delete'] = 'doesn\'t matter but this should not be run';
-        $input['id']     = $user->id;
+        $input['id'] = $user->id;
 
         // Since users are soft deletable, if this fails and we run a $user->delete(), magic box will delete the record
         // but then try to recreate it with the same ID and get a MySQL unique constraint error because the
@@ -568,12 +568,12 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItCanSetDepthRestriction()
     {
         $input = [
-            'username'       => 'javacup@galaxyfarfaraway.com',
-            'name'           => 'Jabba The Hutt',
-            'hands'          => 10,
+            'username' => 'javacup@galaxyfarfaraway.com',
+            'name' => 'Jabba The Hutt',
+            'hands' => 10,
             'times_captured' => 0,
-            'not_fillable'   => 'should be null',
-            'occupation'     => 'Being Gross',
+            'not_fillable' => 'should be null',
+            'occupation' => 'Being Gross',
         ];
 
         $repository = $this->getRepository(User::class, $input);
@@ -625,9 +625,9 @@ class EloquentRepositoryTest extends DBTestCase
         $repository->modify()
             ->setEagerLoads(
                 [
-                'posts',
-                'posts.user',
-            ]
+                    'posts',
+                    'posts.user',
+                ]
             );
         $users = $repository->all()->toArray(); // toArray so we don't pull relations
 
@@ -791,7 +791,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertCount(Tag::count(), $tags->pluck('label')->unique());
 
         $tags->each(
-            fn ($tag) => $this->assertCollectionIsSorted($tag->posts->pluck('title'), $direction)
+            fn($tag) => $this->assertCollectionIsSorted($tag->posts->pluck('title'), $direction)
         );
     }
 
@@ -814,7 +814,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertCount(Tag::count(), $tags->pluck('label')->unique());
 
         $tags->each(
-            fn ($tag) => $this->assertCollectionIsSorted($tag->posts->pluck('title'), $direction)
+            fn($tag) => $this->assertCollectionIsSorted($tag->posts->pluck('title'), $direction)
         );
     }
 
@@ -825,11 +825,11 @@ class EloquentRepositoryTest extends DBTestCase
         $otherUser = User::firstOrCreate(
             ['username' => 'bobbytables@xkcd.com'],
             [
-                'username'       => 'bobbytables@xkcd.com',
-                'name'           => 'Bobby',
-                'hands'          => 2,
+                'username' => 'bobbytables@xkcd.com',
+                'name' => 'Bobby',
+                'hands' => 2,
                 'times_captured' => 0,
-                'occupation'     => 'Student'
+                'occupation' => 'Student'
             ]
         );
 
@@ -845,7 +845,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $additional_filters = [
             'profile.is_human' => '=true',
-            'times_captured'   => '>2'
+            'times_captured' => '>2'
         ];
 
         $repository->modify()->addFilters($additional_filters);
@@ -854,9 +854,9 @@ class EloquentRepositoryTest extends DBTestCase
 
         $filters = $repository->modify()->getFilters();
         $this->assertEquals([
-            'username'         => '~galaxyfarfaraway.com',
+            'username' => '~galaxyfarfaraway.com',
             'profile.is_human' => '=true',
-            'times_captured'   => '>2'
+            'times_captured' => '>2'
         ], $filters);
     }
 
@@ -867,11 +867,11 @@ class EloquentRepositoryTest extends DBTestCase
         $otherUser = User::firstOrCreate(
             ['username' => 'bobbytables@xkcd.com'],
             [
-                'username'       => 'bobbytables@xkcd.com',
-                'name'           => 'Bobby',
-                'hands'          => 2,
+                'username' => 'bobbytables@xkcd.com',
+                'name' => 'Bobby',
+                'hands' => 2,
                 'times_captured' => 0,
-                'occupation'     => 'Student'
+                'occupation' => 'Student'
             ]
         );
 
@@ -890,7 +890,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $filters = $repository->modify()->getFilters();
         $this->assertEquals([
-            'username'         => '~galaxyfarfaraway.com',
+            'username' => '~galaxyfarfaraway.com',
             'profile.is_human' => '=true',
         ], $filters);
     }
@@ -914,7 +914,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repository->accessControl()->addFillable('foo');
 
-        $expect   = User::FILLABLE;
+        $expect = User::FILLABLE;
         $expect[] = 'foo';
 
         $this->assertSame($expect, $repository->accessControl()->getFillable());
@@ -928,7 +928,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repository->accessControl()->addManyFillable(['foo', 'bar', 'baz']);
 
-        $expect   = User::FILLABLE;
+        $expect = User::FILLABLE;
         $expect[] = 'foo';
         $expect[] = 'bar';
         $expect[] = 'baz';
@@ -1240,22 +1240,22 @@ class EloquentRepositoryTest extends DBTestCase
         $post = $this->getRepository(
             Post::class,
             [
-                'title'        => 'All the Tags',
+                'title' => 'All the Tags',
                 'not_fillable' => 'should not be set',
-                'user'         => [
-                    'username'     => 'simon',
+                'user' => [
+                    'username' => 'simon',
                     'not_fillable' => 'should not be set',
-                    'profile'      => [
+                    'profile' => [
                         'favorite_cheese' => 'brie',
                     ],
                 ],
                 'tags' => [
                     [
-                        'label'        => 'Important Stuff',
+                        'label' => 'Important Stuff',
                         'not_fillable' => 'should not be set',
                     ],
                     [
-                        'label'        => 'Less Important Stuff',
+                        'label' => 'Less Important Stuff',
                         'not_fillable' => 'should not be set',
                     ],
                 ],
@@ -1278,7 +1278,7 @@ class EloquentRepositoryTest extends DBTestCase
             User::class,
             [
                 'username' => 'joe',
-                'posts'    => [
+                'posts' => [
                     [
                         'title' => 'Some Great Post',
                     ],
@@ -1303,9 +1303,9 @@ class EloquentRepositoryTest extends DBTestCase
 
         $user = $user->toArray();
 
-        $this->assertTrue(! isset($user['posts'][0]['nothing']));
-        $this->assertTrue(! isset($user['not_exists']));
-        $this->assertTrue(! isset($user['not_includable']));
+        $this->assertTrue(!isset($user['posts'][0]['nothing']));
+        $this->assertTrue(!isset($user['not_exists']));
+        $this->assertTrue(!isset($user['not_includable']));
     }
 
     public function testItDoesNotFilterOnWhatIsNotFilterable()
@@ -1317,7 +1317,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertEquals(User::count(), $repository->all()->count());
 
         $repository->modify()->setFilters([
-            'not_filterable'       => '=foo', // Should not be applied
+            'not_filterable' => '=foo', // Should not be applied
             'posts.not_filterable' => '=foo', // Should not be applied
         ]);
         $found_users = $repository->all();
@@ -1335,7 +1335,7 @@ class EloquentRepositoryTest extends DBTestCase
         $repository->accessControl()->setFilterable([]);
         $repository->modify()->setFilters([
             'profile.is_human' => '=true',
-            'times_captured'   => '>2'
+            'times_captured' => '>2'
         ]);
         $found_users = $repository->all();
 
@@ -1345,7 +1345,7 @@ class EloquentRepositoryTest extends DBTestCase
         $repository->accessControl()->setFilterable(AccessControl::ALLOW_ALL);
         $repository->modify()->setFilters([
             'profile.is_human' => '=true',
-            'times_captured'   => '>2'
+            'times_captured' => '>2'
         ]);
         $found_users = $repository->all();
 
@@ -1494,7 +1494,7 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItCanCheckIfManyOperation()
     {
         $notManyOperationData = ['id' => 1, 'username' => 'bobby'];
-        $manyOperationData    = [['id' => 1, 'username' => 'bobby'], ['id' => 2, 'username' => 'sam']];
+        $manyOperationData = [['id' => 1, 'username' => 'bobby'], ['id' => 2, 'username' => 'sam']];
 
         $this->assertFalse($this->getRepository(User::class, [])->isManyOperation());
         $this->assertFalse($this->getRepository(User::class, $notManyOperationData)->isManyOperation());
@@ -1534,7 +1534,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo = $this->getRepository(
             get_class(
-                new class extends User {
+                new class () extends User {
                     protected $visible = [
                         'id',
                         'username',
@@ -1549,8 +1549,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with    = ['yarderp'];
-                    protected $hidden  = ['stays_hidden'];
+                    protected $with = ['yarderp'];
+                    protected $hidden = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1559,15 +1559,18 @@ class EloquentRepositoryTest extends DBTestCase
                         return 123;
                     }
 
-                    public function getBarbazAttribute() {
+                    public function getBarbazAttribute()
+                    {
                         return 456;
                     }
 
-                    public function getStaysHiddenAttribute() {
+                    public function getStaysHiddenAttribute()
+                    {
                         return false;
                     }
 
-                    public function yarderp() {
+                    public function yarderp()
+                    {
                         return $this->hasOne(Profile::class, 'user_id');
                     }
                 }
@@ -1593,7 +1596,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo = $this->getRepository(
             get_class(
-                new class extends User {
+                new class () extends User {
                     protected $visible = [
                         'id',
                         'username',
@@ -1608,8 +1611,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with    = ['yarderp'];
-                    protected $hidden  = ['stays_hidden'];
+                    protected $with = ['yarderp'];
+                    protected $hidden = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1618,15 +1621,18 @@ class EloquentRepositoryTest extends DBTestCase
                         return 123;
                     }
 
-                    public function getBarbazAttribute() {
+                    public function getBarbazAttribute()
+                    {
                         return 456;
                     }
 
-                    public function getStaysHiddenAttribute() {
+                    public function getStaysHiddenAttribute()
+                    {
                         return false;
                     }
 
-                    public function yarderp() {
+                    public function yarderp()
+                    {
                         return $this->hasOne(Profile::class, 'user_id');
                     }
                 }
@@ -1635,18 +1641,18 @@ class EloquentRepositoryTest extends DBTestCase
         $repo->modify()->addPicks(['id', 'username', 'foobar', 'barbaz']);
 
         $usersWithPicks = $repo->all();
-        $this->assertTrue($usersWithPicks->every(fn ($userWithPicks) => ['id', 'username', 'foobar', 'barbaz'] === array_keys($userWithPicks->toArray())));
+        $this->assertTrue($usersWithPicks->every(fn($userWithPicks) => ['id', 'username', 'foobar', 'barbaz'] === array_keys($userWithPicks->toArray())));
 
         $repo->modify()->setPicks(['id', 'username']);
         $usersWithPicks = $repo->all();
-        $this->assertTrue($usersWithPicks->every(fn ($userWithPicks) => ['id', 'username'] === array_keys($userWithPicks->toArray())));
+        $this->assertTrue($usersWithPicks->every(fn($userWithPicks) => ['id', 'username'] === array_keys($userWithPicks->toArray())));
 
         $repo->modify()->setPicks(['id', 'username', 'stay_hidden', 'yarderp']);
         $usersWithPicks = $repo->all();
-        $this->assertTrue($usersWithPicks->every(fn ($userWithPicks) => ['id', 'username', 'yarderp'] === array_keys($userWithPicks->toArray())));
+        $this->assertTrue($usersWithPicks->every(fn($userWithPicks) => ['id', 'username', 'yarderp'] === array_keys($userWithPicks->toArray())));
 
         $paginatedUsersWithPicks = $repo->paginate(10);
-        $this->assertTrue($paginatedUsersWithPicks->getCollection()->every(fn ($userWithPicks) => ['id', 'username', 'yarderp'] === array_keys($userWithPicks->toArray())));
+        $this->assertTrue($paginatedUsersWithPicks->getCollection()->every(fn($userWithPicks) => ['id', 'username', 'yarderp'] === array_keys($userWithPicks->toArray())));
     }
 
     public function testItShowsAllVisibleFieldsWhenNoPicksAreApplied()
@@ -1655,7 +1661,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo = $this->getRepository(
             get_class(
-                new class extends User {
+                new class () extends User {
                     protected $visible = [
                         'id',
                         'username',
@@ -1670,8 +1676,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with    = ['yarderp'];
-                    protected $hidden  = ['stays_hidden'];
+                    protected $with = ['yarderp'];
+                    protected $hidden = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1680,19 +1686,23 @@ class EloquentRepositoryTest extends DBTestCase
                         return 123;
                     }
 
-                    public function getBarbazAttribute() {
+                    public function getBarbazAttribute()
+                    {
                         return 456;
                     }
 
-                    public function getStaysHiddenAttribute() {
+                    public function getStaysHiddenAttribute()
+                    {
                         return false;
                     }
 
-                    public function yarderp() {
+                    public function yarderp()
+                    {
                         return $this->hasOne(Profile::class, 'user_id');
                     }
 
-                    public function profile() {
+                    public function profile()
+                    {
                         return $this->hasOne(Profile::class, 'user_id');
                     }
                 }
@@ -1711,7 +1721,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo->modify()->setEagerLoads(['profile']);
         $usersWithPicks = Collection::wrap([$repo->firstOrFail(), $repo->first(), $repo->find(1), $repo->findOrFail(1)])->concat($repo->all());
-        $usersWithPicks->each(fn ($userWithPicks) => $this->assertEqualsCanonicalizing(array_diff($userWithPicks->getVisible(), array_keys($userWithPicks->toArray())), ['posts']));
+        $usersWithPicks->each(fn($userWithPicks) => $this->assertEqualsCanonicalizing(array_diff($userWithPicks->getVisible(), array_keys($userWithPicks->toArray())), ['posts']));
     }
 
 
@@ -1733,7 +1743,7 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $valueToAvoid = $direction == 'desc' ? -1 : 1;
         $collection->sliding(2)->eachSpread(function ($previous, $current) use ($valueToAvoid, $direction) {
-            $word    = $valueToAvoid == -1 ? 'after' : 'before';
+            $word = $valueToAvoid == -1 ? 'after' : 'before';
             $message = "Failed asserting that the collection is sorted in $direction order. $previous does not come $word to $current.";
             $this->assertNotEquals($valueToAvoid, $previous <=> $current, $message);
         });

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1494,7 +1494,7 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItCanCheckIfManyOperation()
     {
         $notManyOperationData = ['id' => 1, 'username' => 'bobby'];
-        $manyOperationData    = [['id' => 1, 'username' => 'bobby'], ['id' => 2, 'username' => 'sam']];
+        $manyOperationData = [['id' => 1, 'username' => 'bobby'], ['id' => 2, 'username' => 'sam']];
 
         $this->assertFalse($this->getRepository(User::class, [])->isManyOperation());
         $this->assertFalse($this->getRepository(User::class, $notManyOperationData)->isManyOperation());
@@ -1549,8 +1549,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with    = ['yarderp'];
-                    protected $hidden  = ['stays_hidden'];
+                    protected $with = ['yarderp'];
+                    protected $hidden = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1611,8 +1611,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with    = ['yarderp'];
-                    protected $hidden  = ['stays_hidden'];
+                    protected $with = ['yarderp'];
+                    protected $hidden = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1676,8 +1676,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with    = ['yarderp'];
-                    protected $hidden  = ['stays_hidden'];
+                    protected $with = ['yarderp'];
+                    protected $hidden = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1714,14 +1714,14 @@ class EloquentRepositoryTest extends DBTestCase
         $usersWithPicks = Collection::wrap([$repo->firstOrFail(), $repo->first(), $repo->find(1), $repo->findOrFail(1)])->concat($repo->all());
         $usersWithPicks->each(function ($userWithPicks) {
             $modelToArray = $userWithPicks->toArray();
-            $modelKeys    = array_keys($modelToArray);
-            $diff         = array_diff($userWithPicks->getVisible(), $modelKeys);
+            $modelKeys = array_keys($modelToArray);
+            $diff = array_diff($userWithPicks->getVisible(), $modelKeys);
             $this->assertEqualsCanonicalizing($diff, ['posts', 'profile']);
         });
 
         $repo->modify()->setEagerLoads(['profile']);
         $usersWithPicks = Collection::wrap([$repo->firstOrFail(), $repo->first(), $repo->find(1), $repo->findOrFail(1)])->concat($repo->all());
-        $usersWithPicks->each(fn ($userWithPicks) => $this->assertEqualsCanonicalizing(array_diff($userWithPicks->getVisible(), array_keys($userWithPicks->toArray())), ['posts']));
+        $usersWithPicks->each(fn($userWithPicks) => $this->assertEqualsCanonicalizing(array_diff($userWithPicks->getVisible(), array_keys($userWithPicks->toArray())), ['posts']));
     }
 
 
@@ -1743,7 +1743,7 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $valueToAvoid = $direction == 'desc' ? -1 : 1;
         $collection->sliding(2)->eachSpread(function ($previous, $current) use ($valueToAvoid, $direction) {
-            $word    = $valueToAvoid == -1 ? 'after' : 'before';
+            $word = $valueToAvoid == -1 ? 'after' : 'before';
             $message = "Failed asserting that the collection is sorted in $direction order. $previous does not come $word to $current.";
             $this->assertNotEquals($valueToAvoid, $previous <=> $current, $message);
         });

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1494,7 +1494,7 @@ class EloquentRepositoryTest extends DBTestCase
     public function testItCanCheckIfManyOperation()
     {
         $notManyOperationData = ['id' => 1, 'username' => 'bobby'];
-        $manyOperationData = [['id' => 1, 'username' => 'bobby'], ['id' => 2, 'username' => 'sam']];
+        $manyOperationData    = [['id' => 1, 'username' => 'bobby'], ['id' => 2, 'username' => 'sam']];
 
         $this->assertFalse($this->getRepository(User::class, [])->isManyOperation());
         $this->assertFalse($this->getRepository(User::class, $notManyOperationData)->isManyOperation());
@@ -1549,8 +1549,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with = ['yarderp'];
-                    protected $hidden = ['stays_hidden'];
+                    protected $with    = ['yarderp'];
+                    protected $hidden  = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1611,8 +1611,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with = ['yarderp'];
-                    protected $hidden = ['stays_hidden'];
+                    protected $with    = ['yarderp'];
+                    protected $hidden  = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1676,8 +1676,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with = ['yarderp'];
-                    protected $hidden = ['stays_hidden'];
+                    protected $with    = ['yarderp'];
+                    protected $hidden  = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1714,14 +1714,14 @@ class EloquentRepositoryTest extends DBTestCase
         $usersWithPicks = Collection::wrap([$repo->firstOrFail(), $repo->first(), $repo->find(1), $repo->findOrFail(1)])->concat($repo->all());
         $usersWithPicks->each(function ($userWithPicks) {
             $modelToArray = $userWithPicks->toArray();
-            $modelKeys = array_keys($modelToArray);
-            $diff = array_diff($userWithPicks->getVisible(), $modelKeys);
+            $modelKeys    = array_keys($modelToArray);
+            $diff         = array_diff($userWithPicks->getVisible(), $modelKeys);
             $this->assertEqualsCanonicalizing($diff, ['posts', 'profile']);
         });
 
         $repo->modify()->setEagerLoads(['profile']);
         $usersWithPicks = Collection::wrap([$repo->firstOrFail(), $repo->first(), $repo->find(1), $repo->findOrFail(1)])->concat($repo->all());
-        $usersWithPicks->each(fn($userWithPicks) => $this->assertEqualsCanonicalizing(array_diff($userWithPicks->getVisible(), array_keys($userWithPicks->toArray())), ['posts']));
+        $usersWithPicks->each(fn ($userWithPicks) => $this->assertEqualsCanonicalizing(array_diff($userWithPicks->getVisible(), array_keys($userWithPicks->toArray())), ['posts']));
     }
 
 
@@ -1743,7 +1743,7 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $valueToAvoid = $direction == 'desc' ? -1 : 1;
         $collection->sliding(2)->eachSpread(function ($previous, $current) use ($valueToAvoid, $direction) {
-            $word = $valueToAvoid == -1 ? 'after' : 'before';
+            $word    = $valueToAvoid == -1 ? 'after' : 'before';
             $message = "Failed asserting that the collection is sorted in $direction order. $previous does not come $word to $current.";
             $this->assertNotEquals($valueToAvoid, $previous <=> $current, $message);
         });

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -84,7 +84,7 @@ class EloquentRepositoryTest extends DBTestCase
 
     public function testItFirstReturnsNullWhenTheQueryHasNoResults()
     {
-        $model = new class() extends User {
+        $model = new class () extends User {
             public static function query()
             {
                 return \Mockery::mock(parent::query())
@@ -99,7 +99,7 @@ class EloquentRepositoryTest extends DBTestCase
 
     public function testItFailsWhenFirstOrFailQueryHasNoResults()
     {
-        $model = new class() extends User {
+        $model = new class () extends User {
             public static function query()
             {
                 return \Mockery::mock(parent::query())
@@ -1533,7 +1533,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo = $this->getRepository(
             get_class(
-                new class() extends User {
+                new class () extends User {
                     protected $visible = [
                         'id',
                         'username',
@@ -1548,8 +1548,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with = ['yarderp'];
-                    protected $hidden = ['stays_hidden'];
+                    protected $with    = ['yarderp'];
+                    protected $hidden  = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1595,7 +1595,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo = $this->getRepository(
             get_class(
-                new class() extends User {
+                new class () extends User {
                     protected $visible = [
                         'id',
                         'username',
@@ -1610,8 +1610,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with = ['yarderp'];
-                    protected $hidden = ['stays_hidden'];
+                    protected $with    = ['yarderp'];
+                    protected $hidden  = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1660,7 +1660,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         $repo = $this->getRepository(
             get_class(
-                new class() extends User {
+                new class () extends User {
                     protected $visible = [
                         'id',
                         'username',
@@ -1675,8 +1675,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with = ['yarderp'];
-                    protected $hidden = ['stays_hidden'];
+                    protected $with    = ['yarderp'];
+                    protected $hidden  = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1713,8 +1713,8 @@ class EloquentRepositoryTest extends DBTestCase
         $usersWithPicks = Collection::wrap([$repo->firstOrFail(), $repo->first(), $repo->find(1), $repo->findOrFail(1)])->concat($repo->all());
         $usersWithPicks->each(function ($userWithPicks) {
             $modelToArray = $userWithPicks->toArray();
-            $modelKeys = array_keys($modelToArray);
-            $diff = array_diff($userWithPicks->getVisible(), $modelKeys);
+            $modelKeys    = array_keys($modelToArray);
+            $diff         = array_diff($userWithPicks->getVisible(), $modelKeys);
             $this->assertEqualsCanonicalizing($diff, ['posts', 'profile']);
         });
 
@@ -1742,7 +1742,7 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $valueToAvoid = $direction == 'desc' ? -1 : 1;
         $collection->sliding(2)->eachSpread(function ($previous, $current) use ($valueToAvoid, $direction) {
-            $word = $valueToAvoid == -1 ? 'after' : 'before';
+            $word    = $valueToAvoid == -1 ? 'after' : 'before';
             $message = "Failed asserting that the collection is sorted in $direction order. $previous does not come $word to $current.";
             $this->assertNotEquals($valueToAvoid, $previous <=> $current, $message);
         });

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -3,7 +3,6 @@
 namespace Koala\Pouch\Tests\Models;
 
 use Koala\Pouch\Contracts\PouchResource;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 


### PR DESCRIPTION
# What

Transforms the models that come out of Repositories to only show which fields are visible after a `pick` operation.

# Why

The MVP `pick` functionality only restricts which columns were included in Repository queries. But, additional attributes and  relationships defined in the model were still visible.

This PR adds an additional model transformation step to hide fields that are not part of the `pick` list, and hide relationships that are not part of the `pick` and `include` lists.

# How

Laravel's Eloquent Models can define additional attributes that are not hydrated by a database query.  These attributes are defined through an `$appends` property, and relationships can be appended through the `$with` property.

The `EloquentRepository` now runs all models returned from a database query through an `applyPicksToModel` method to hide attributes that are appended to a model after the query is executed.

I may expand this into a customizable model transformation pipeline that will process repository results automagically.

# CC 🐨
