### PR TITLE
Add support for Laravel 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build
         uses: shivammathur/setup-php@v2
         with:
-          php-version: {{ matrix.php-version }}
+          php-version: ${{ matrix.php-version }}
           coverage: xdebug
           extensions: sqlite3, pdo_sqlite
           tools: composer, phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
-          tools: php-cs-fixer
+          tools: php-cs-fixer:3.4
       - name: Run Lint Check
         run: php-cs-fixer fix --dry-run -vv --diff --config=.php_cs.dist.php
   phan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         laravel-version: ['^8', '^9']
         php-version: ['^7.4', '^8.0', '^8.1']
         exclude:
-          - laravel-version: '^8'
+          - laravel-version: '^8.0'
             php-version: '^8.2'
           - laravel-version: '^9'
             php-version: '^7.4'
@@ -25,12 +25,12 @@ jobs:
       - name: Build
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: "${{ matrix.php-version }}"
           coverage: xdebug
           extensions: sqlite3, pdo_sqlite
           tools: composer, phpunit
       - name: Require Laravel
-        run: composer require ${{ matrix.laravel-version }}
+        run: composer require "${{ matrix.laravel-version }}"
 #      - name: Set testbench dependency
 #        run: composer require orchestra/testbench "^6"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         exclude:
           - laravel-version: '^8.0'
             php-version: '8.2'
-          - laravel-version: '^9'
+          - laravel-version: '^9.0'
             php-version: '7.4'
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Set testbench dependency
         run: composer require orchestra/testbench "^6"
-#      - name: Composer
-#        run: composer install
+      - name: Composer
+        run: composer install
       - name: Run Tests
         run: composer run test-coverage
   testing-74:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         laravel-version: ['^8', '^9']
         include:
           - laravel-version: '^8'
-            php-version: ['7.4', '8.0', '8.1']
+            php-version: ['^7.4', '^8.0', '^8.1']
           - laravel-version: '^9'
-            php-version: ['8.0', '8.1', '8.2']
+            php-version: ['^8.0', '^8.1', '^8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         laravel-version: ['^8', '^9']
-        php-version: ['^7.4', '^8.0', '^8.1']
+        php-version: ['7.4', '8.0', '8.1']
         exclude:
           - laravel-version: '^8.0'
-            php-version: '^8.2'
+            php-version: '8.2'
           - laravel-version: '^9'
-            php-version: '^7.4'
+            php-version: '7.4'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   testing-php-laravel-combinations:
     runs-on: ubuntu-latest
-    matrix:
-      laravel-version: ['8', '9']
-      php-version: ['7.4', '8.0', '8.1', '8.2']
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel-version: ['8', '9']
+        php-version: ['7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "${{ matrix.php-version }}"
+          php-version: ${{ matrix.php-version }}
           coverage: xdebug
           extensions: sqlite3, pdo_sqlite
           tools: composer, phpunit
@@ -39,7 +39,7 @@ jobs:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-testing-php${{ matrix.php-version }}-laravel${{ matrix.laravel-version }}-${{ hashFiles('**/composer.json') }}
       - name: Require Laravel
-        run: composer require laravel/framework "${{ matrix.laravel-version }}"
+        run: composer require laravel/framework ${{ matrix.laravel-version }}
       - name: Composer
         run: composer install
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        laravel-version: ['8', '9']
-        php-version: ['7.4', '8.0', '8.1', '8.2']
+        - laravel-version: ['8']
+          php-version: ['7.4', '8.0', '8.1']
+        - laravel-version: ['9']
+          php-version: ['8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
         uses: shivammathur/setup-php@v2
         with:
-          php-version: {{ matrix.php-version}}
+          php-version: {{ matrix.php-version }}
           coverage: xdebug
           extensions: sqlite3, pdo_sqlite
           tools: composer, phpunit
+      - name: Require Laravel
+        run: composer require ${{ matrix.laravel-version }}
 #      - name: Set testbench dependency
 #        run: composer require orchestra/testbench "^6"
+
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,23 @@ on:
       - main
 
 jobs:
-  testing-php8-laravel9:
+  testing-php-laravel-combinations:
     runs-on: ubuntu-latest
+    matrix:
+      laravel-version: ['8', '9']
+      php-version: ['7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: {{ matrix.php-version}}
           coverage: xdebug
           extensions: sqlite3, pdo_sqlite
           tools: composer, phpunit
+#      - name: Set testbench dependency
+#        run: composer require orchestra/testbench "^6"
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
@@ -25,59 +30,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-testing-php8-laravel9-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-      - name: Composer
-        run: composer install
-      - name: Run Tests
-        run: composer run test-coverage
-  testing-php8-laravel8:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.0'
-          coverage: xdebug
-          extensions: sqlite3, pdo_sqlite
-          tools: composer, phpunit
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-testing-php8-laravel8-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-      - name: Set testbench dependency
-        run: composer require orchestra/testbench "^6"
-      - name: Composer
-        run: composer install
-      - name: Run Tests
-        run: composer run test-coverage
-  testing-74:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: xdebug
-          extensions: sqlite3, pdo_sqlite
-          tools: composer, phpunit
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php7-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-testing-php${{ matrix.php-version }}-laravel${{ matrix.laravel-version }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
       - name: Composer
         run: composer install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         laravel-version: ['^8', '^9']
-        include:
+        php-version: ['^7.4', '^8.0', '^8.1']
+        exclude:
           - laravel-version: '^8'
-            php-version: ['^7.4', '^8.0', '^8.1']
+            php-version: '^8.2'
           - laravel-version: '^9'
-            php-version: ['^8.0', '^8.1', '^8.2']
+            php-version: '^7.4'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        - laravel-version: ['8']
-          php-version: ['7.4', '8.0', '8.1']
-        - laravel-version: ['9']
-          php-version: ['8.0', '8.1', '8.2']
+        laravel-version: ['^8', '^9']
+        include:
+          - laravel-version: '^8'
+            php-version: ['7.4', '8.0', '8.1']
+          - laravel-version: '^9'
+            php-version: ['8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   testing-php-laravel-combinations:
+    name: Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        laravel-version: ['^8', '^9']
+        laravel-version: ['^8.0', '^9.0']
         php-version: ['7.4', '8.0', '8.1']
         exclude:
           - laravel-version: '^8.0'
@@ -29,10 +29,6 @@ jobs:
           coverage: xdebug
           extensions: sqlite3, pdo_sqlite
           tools: composer, phpunit
-      - name: Require Laravel
-        run: composer require "${{ matrix.laravel-version }}"
-#      - name: Set testbench dependency
-#        run: composer require orchestra/testbench "^6"
 
       - name: Get composer cache directory
         id: composer-cache
@@ -42,7 +38,10 @@ jobs:
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-testing-php${{ matrix.php-version }}-laravel${{ matrix.laravel-version }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+      - name: Require Laravel
+        run: composer require laravel/framework "${{ matrix.laravel-version }}"
+      #      - name: Set testbench dependency
+      #        run: composer require orchestra/testbench "^6"
       - name: Composer
         run: composer install
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  testing-8:
+  testing-php8-laravel9:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,10 +25,37 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php8-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-testing-php8-laravel9-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
       - name: Composer
         run: composer install
+      - name: Run Tests
+        run: composer run test-coverage
+  testing-php8-laravel8:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: xdebug
+          extensions: sqlite3, pdo_sqlite
+          tools: composer, phpunit
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-testing-php8-laravel8-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Set testbench dependency
+        run: composer require orchestra/testbench "^6"
+#      - name: Composer
+#        run: composer install
       - name: Run Tests
         run: composer run test-coverage
   testing-74:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
           key: ${{ runner.os }}-composer-testing-php${{ matrix.php-version }}-laravel${{ matrix.laravel-version }}-${{ hashFiles('**/composer.json') }}
       - name: Require Laravel
         run: composer require laravel/framework "${{ matrix.laravel-version }}"
-      #      - name: Set testbench dependency
-      #        run: composer require orchestra/testbench "^6"
       - name: Composer
         run: composer install
       - name: Run Tests

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,9 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9",
-		"orchestra/testbench": "^6|^7.13",
-		"mockery/mockery": "^1"
+		"orchestra/testbench": "^6",
+		"mockery/mockery": "^1",
+		"friendsofphp/php-cs-fixer": "3.4.*"
 	},
 	"authors": [
 		{

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
 	"homepage": "https://koala.io/",
 	"require": {
 		"php": "^7.4|^8.0",
-		"illuminate/database": "^8"
+		"illuminate/database": "^8|^9"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9",
-		"orchestra/testbench": "^6",
+		"orchestra/testbench": "^6|^7.13",
 		"mockery/mockery": "^1"
 	},
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9",
-		"orchestra/testbench": "^6",
+		"orchestra/testbench": "^6|^7",
 		"mockery/mockery": "^1",
 		"friendsofphp/php-cs-fixer": "3.4.*"
 	},

--- a/src/EloquentQueryModifier.php
+++ b/src/EloquentQueryModifier.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**
@@ -257,7 +256,7 @@ class EloquentQueryModifier implements QueryModifier
     /**
      * Set aggregate functions.
      *
-     * @param array $aggregate
+     * @param array<array{0: string, 1: string}> $aggregate
      *
      * @return \Koala\Pouch\Contracts\QueryModifier
      */
@@ -355,7 +354,7 @@ class EloquentQueryModifier implements QueryModifier
         $function        = strtolower(key($aggregate));
 
         if (in_array($function, $allowed_aggregations, true) && in_array($column, $allowed_columns, true)) {
-            $this->query()->addSelect(DB::raw($function . '(' . $column . ') as aggregate'));
+            $this->query()->getQuery()->aggregate = ['columns' => [$column], 'function' => $function];
 
             if (! empty($valid_group)) {
                 $this->query()->addSelect($valid_group);

--- a/tests/EloquentQueryModifierTest.php
+++ b/tests/EloquentQueryModifierTest.php
@@ -111,7 +111,7 @@ class EloquentQueryModifierTest extends DBTestCase
         $this->assertNull($query->getQuery()->aggregate);
     }
 
-    protected function aggregateFunctionDataProvider()
+    public function aggregateFunctionDataProvider()
     {
         return [
             'Count' => ['count'],

--- a/tests/EloquentQueryModifierTest.php
+++ b/tests/EloquentQueryModifierTest.php
@@ -115,10 +115,10 @@ class EloquentQueryModifierTest extends DBTestCase
     {
         return [
             'Count' => ['count'],
-            'Min' => ['min'],
-            'Max' => ['max'],
-            'Sum' => ['sum'],
-            'Avg' => ['avg']
+            'Min'   => ['min'],
+            'Max'   => ['max'],
+            'Sum'   => ['sum'],
+            'Avg'   => ['avg']
         ];
     }
 }

--- a/tests/EloquentQueryModifierTest.php
+++ b/tests/EloquentQueryModifierTest.php
@@ -39,13 +39,8 @@ class EloquentQueryModifierTest extends DBTestCase
 
     public function testItDoesNotApplySelectWhenThereAreNoPicksDefined()
     {
-        Artisan::call('db:seed', [
-            '--class' => FilterDataSeeder::class
-        ]);
-
-        /** @var Model $model */
-        $model = User::findOrFail(1);
-        $query = $model->newQuery();
+        $model = new User();
+        $query = $model->query();
 
         (new EloquentQueryModifier())->setQuery($query)->apply(new EloquentAccessControl(), get_class($model));
 
@@ -54,13 +49,8 @@ class EloquentQueryModifierTest extends DBTestCase
 
     public function testItDoesNotSelectPicksThatAreNotInTheModelTable()
     {
-        Artisan::call('db:seed', [
-            '--class' => FilterDataSeeder::class
-        ]);
-
-        /** @var Model $model */
-        $model = User::findOrFail(1);
-        $query = $model->newQuery();
+        $model = new User();
+        $query = $model->query();
 
         (new EloquentQueryModifier())->setQuery($query)
             ->setPicks([$model->getKeyName(), 'not-in-this-model'])
@@ -72,18 +62,63 @@ class EloquentQueryModifierTest extends DBTestCase
 
     public function testItDoesNotApplySelectWhenNoneOfThePicksMatchColumns()
     {
-        Artisan::call('db:seed', [
-            '--class' => FilterDataSeeder::class
-        ]);
-
-        /** @var Model $model */
-        $model = User::findOrFail(1);
-        $query = $model->newQuery();
+        $model = new User();
+        $query = $model->query();
 
         (new EloquentQueryModifier())->setQuery($query)
             ->setPicks(['not-in-this-model', 'another-not-in-this-model'])
             ->apply(new EloquentAccessControl(), get_class($model));
 
         $this->assertNull($query->getQuery()->columns);
+    }
+
+    /**
+     * @dataProvider aggregateFunctionDataProvider
+     */
+    public function testItCanApplyAnAggregation(string $function)
+    {
+        $model = new User();
+        $query = $model->query();
+
+        (new EloquentQueryModifier())->setQuery($query)
+            ->setAggregate([$function => 'hands'])
+            ->apply(new EloquentAccessControl(), get_class($model));
+
+        $this->assertEqualsCanonicalizing(['function' => $function, 'columns' => ['hands']], $query->getQuery()->aggregate);
+    }
+
+    public function testItOnlyAppliesTheFirstAggregation()
+    {
+        $model = new User();
+        $query = $model->query();
+
+        (new EloquentQueryModifier())->setQuery($query)
+            ->setAggregate(['sum' => 'hands', 'avg' => 'hands', 'max' => 'hands'])
+            ->apply(new EloquentAccessControl(), get_class($model));
+
+        $this->assertEqualsCanonicalizing(['function' => 'sum', 'columns' => ['hands']], $query->getQuery()->aggregate);
+    }
+
+    public function testItDoesNotApplyInvalidAggregationFunctions()
+    {
+        $model = new User();
+        $query = $model->query();
+
+        (new EloquentQueryModifier())->setQuery($query)
+            ->setAggregate(['not-valid' => 'hands'])
+            ->apply(new EloquentAccessControl(), get_class($model));
+
+        $this->assertNull($query->getQuery()->aggregate);
+    }
+
+    protected function aggregateFunctionDataProvider()
+    {
+        return [
+            'Count' => ['count'],
+            'Min' => ['min'],
+            'Max' => ['max'],
+            'Sum' => ['sum'],
+            'Avg' => ['avg']
+        ];
     }
 }

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1581,10 +1581,10 @@ class EloquentRepositoryTest extends DBTestCase
     {
         return [
             'Count' => ['count'],
-            'Min' => ['min'],
-            'Max' => ['max'],
-            'Sum' => ['sum'],
-            'Avg' => ['avg']
+            'Min'   => ['min'],
+            'Max'   => ['max'],
+            'Sum'   => ['sum'],
+            'Avg'   => ['avg']
         ];
     }
 

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1539,7 +1539,7 @@ class EloquentRepositoryTest extends DBTestCase
 
         //Aggregate over all Users
         $expectedValue = User::aggregate($function, ['id']);
-        $repository = $this->getRepository(User::class);
+        $repository    = $this->getRepository(User::class);
         $repository->modify()->setAggregate([$function => 'id']);
         $result = $repository->all();
         $this->assertCount(1, $result);
@@ -1547,10 +1547,9 @@ class EloquentRepositoryTest extends DBTestCase
 
         //Aggregate on one user by input id
         $expectedValue = User::where('id', User::first()->id)->aggregate($function, ['id']);
-        $repository = $this->getRepository(User::class)->setInput(['id' => User::first()->id]);
+        $repository    = $this->getRepository(User::class)->setInput(['id' => User::first()->id]);
         $repository->modify()->setAggregate([$function => 'id']);
-        $result = $repository->read();
-        $this->assertSame($expectedValue, $result->aggregate);
+        $this->assertSame($expectedValue, $repository->read()->aggregate);
 
         //Aggregate on multiple users by filter
         $expectedValue = User::where('hands', '<', 2)->aggregate($function, ['id']);
@@ -1561,16 +1560,15 @@ class EloquentRepositoryTest extends DBTestCase
 
         //Aggregate on one user by filter
         $expectedValue = User::where('id', User::first()->id)->aggregate($function, ['id']);
-        $repository = $this->getRepository(User::class)->setInput(['id' => User::first()->id]);
+        $repository    = $this->getRepository(User::class)->setInput(['id' => User::first()->id]);
         $repository->modify()->setAggregate([$function => 'id']);
         $repository->modify()->addFilter('name', '='.User::first()->name);
-        $result = $repository->read();
-        $this->assertSame($expectedValue, $result->aggregate);
+        $this->assertSame($expectedValue, $repository->read()->aggregate);
 
         //Aggregate on zero users
-        $fakeName = $this->faker->name;
+        $fakeName      = $this->faker->name;
         $expectedValue = User::query()->where('name', $fakeName)->aggregate($function, ['name']);
-        $repository = $this->getRepository(User::class);
+        $repository    = $this->getRepository(User::class);
         $repository->modify()->setAggregate([$function => 'id']);
         $repository->modify()->addFilter('name', '='.$fakeName);
         $result = $repository->first();
@@ -1701,8 +1699,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with    = ['yarderp'];
-                    protected $hidden  = ['stays_hidden'];
+                    protected $with = ['yarderp'];
+                    protected $hidden = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1763,8 +1761,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with    = ['yarderp'];
-                    protected $hidden  = ['stays_hidden'];
+                    protected $with = ['yarderp'];
+                    protected $hidden = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1828,8 +1826,8 @@ class EloquentRepositoryTest extends DBTestCase
                         'yarderp'
                     ];
                     protected $appends = ['foobar', 'barbaz'];
-                    protected $with    = ['yarderp'];
-                    protected $hidden  = ['stays_hidden'];
+                    protected $with = ['yarderp'];
+                    protected $hidden = ['stays_hidden'];
 
                     protected $table = 'users';
 
@@ -1866,8 +1864,8 @@ class EloquentRepositoryTest extends DBTestCase
         $usersWithPicks = Collection::wrap([$repo->firstOrFail(), $repo->first(), $repo->find(1), $repo->findOrFail(1)])->concat($repo->all());
         $usersWithPicks->each(function ($userWithPicks) {
             $modelToArray = $userWithPicks->toArray();
-            $modelKeys    = array_keys($modelToArray);
-            $diff         = array_diff($userWithPicks->getVisible(), $modelKeys);
+            $modelKeys  = array_keys($modelToArray);
+            $diff = array_diff($userWithPicks->getVisible(), $modelKeys);
             $this->assertEqualsCanonicalizing($diff, ['posts', 'profile']);
         });
 
@@ -1895,7 +1893,7 @@ class EloquentRepositoryTest extends DBTestCase
     {
         $valueToAvoid = $direction == 'desc' ? -1 : 1;
         $collection->sliding(2)->eachSpread(function ($previous, $current) use ($valueToAvoid, $direction) {
-            $word    = $valueToAvoid == -1 ? 'after' : 'before';
+            $word = $valueToAvoid == -1 ? 'after' : 'before';
             $message = "Failed asserting that the collection is sorted in $direction order. $previous does not come $word $current.";
             $this->assertNotEquals($valueToAvoid, $previous <=> $current, $message);
         });

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1864,7 +1864,7 @@ class EloquentRepositoryTest extends DBTestCase
         $usersWithPicks = Collection::wrap([$repo->firstOrFail(), $repo->first(), $repo->find(1), $repo->findOrFail(1)])->concat($repo->all());
         $usersWithPicks->each(function ($userWithPicks) {
             $modelToArray = $userWithPicks->toArray();
-            $modelKeys  = array_keys($modelToArray);
+            $modelKeys = array_keys($modelToArray);
             $diff = array_diff($userWithPicks->getVisible(), $modelKeys);
             $this->assertEqualsCanonicalizing($diff, ['posts', 'profile']);
         });

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -1577,7 +1577,7 @@ class EloquentRepositoryTest extends DBTestCase
         $this->assertSame($expectedValue, $result->aggregate);
     }
 
-    protected function aggregateFunctionDataProvider()
+    public function aggregateFunctionDataProvider()
     {
         return [
             'Count' => ['count'],


### PR DESCRIPTION
# What

Updates composer dependencies to work with Laravel 9.

# Why

Laravel 8 is approaching EOL on January 24, 2023.

# CC 🐨
