### PR TITLE
Support HasManyThrough relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,55 @@ $user = $repository->save();
 When `$repository->save()` is invoked, a User will be created with the username "Steve", and a Post will
 be created with the `user_id` belonging to that User. The nonsensical "nonsense" property is simply
 ignored, because it does not actually exist on the table storing Users.
+---
 
+***A limitation on Eloquent HasManyThrough relationships:***
+
+Inputs that define a model related through a `HasManyThrough` relationship must refer to an already existing model.
+In this example, a `User` has many `Reaction`s through a `Post`. The `Reaction` model must exist and be related to a
+`Post` in order to correctly relate to the `User`.
+
+```php
+$repository = (new EloquentRepository)
+    ->setModelClass('User')
+    ->setInput([
+        'username' => 'steve',        
+        'posts'    => [
+            'title' => 'Stuff',
+        ],
+        'reactions' => [
+            [
+                'id': 1 //The Reaction model must already exist, and relate to a Post
+            ]
+        ]
+    ]);
+
+$user = $repository->save();
+```
+A workaround for new `Reaction` and `Post` models attached to a `User` involves nesting the `Reaction` model data under the related `Post`
+```php
+$repository = (new EloquentRepository)
+    ->setModelClass('User')
+    ->setInput([
+        'username' => 'steve',        
+        //The Post is related to the User, and the Reaction is related to the Post. User Reactions are related through the Post.
+        'posts'    => [
+            'title' => 'Stuff',
+            'reactions' => [ 
+                [
+                    'name' => 'John Doe',
+                    'icon' => 'thumbs-up'
+                ]
+            ]
+        ],
+        
+    ]);
+
+$user = $repository->save();
+```
+Support for new models defined through a `HasThroughMany` relationship will come soon.
+
+---
 By itself, EloquentRepository is a blunt weapon with no access controls that should be avoided in any
 public APIs. It will clobber every relationship it touches without prejudice. For example, the following
 is a BAD way to add a new Post for the user we just created.

--- a/src/EloquentQueryModifier.php
+++ b/src/EloquentQueryModifier.php
@@ -4,10 +4,8 @@ namespace Koala\Pouch;
 
 use Closure;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
-use Illuminate\Database\Query\Expression;
 use Koala\Pouch\Contracts\AccessControl;
 use Koala\Pouch\Contracts\QueryModifier;
-use Koala\Pouch\Tests\Models\User;
 use Koala\Pouch\Utility\ChecksModelFields;
 use Koala\Pouch\Utility\ChecksRelations;
 use Illuminate\Database\Eloquent\Builder;
@@ -19,7 +17,6 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use ReflectionClass;
 
 /**
  * Class EloquentQueryModifier

--- a/src/EloquentQueryModifier.php
+++ b/src/EloquentQueryModifier.php
@@ -658,11 +658,11 @@ class EloquentQueryModifier implements QueryModifier
                     //Use the relationship to build a new query without the model constraint and name the subtable the same as the requested relationship name
                     //Alias the "first" key to prevent collisions with other columns
                     $subQuery = $instance->$relation()->select([
-                        $related->getQualifiedFirstKeyName().' AS '.($uniqeFirstKey = str_replace('.', '_', uniqId().$related->getQualifiedFirstKeyName())), //Id to left join on
+                        $related->getQualifiedFirstKeyName().' AS '.($uniqueFirstKey = str_replace('.', '_', uniqid().$related->getQualifiedFirstKeyName())), //Id to left join on
                         "$relation.$field" //Relation and field that comes from the aggregation function
                     ]);
 
-                    $query->leftJoinSub($subQuery, $relation, $related->getQualifiedLocalKeyName(), $uniqeFirstKey, $related->getQualifiedForeignKeyName());
+                    $query->leftJoinSub($subQuery, $relation, $related->getQualifiedLocalKeyName(), $uniqueFirstKey, $related->getQualifiedForeignKeyName());
                 });
                 break;
         }

--- a/src/EloquentRepository.php
+++ b/src/EloquentRepository.php
@@ -520,6 +520,8 @@ class EloquentRepository implements Repository
                 break;
             case HasManyThrough::class:
                 //Assume that the input(s) contains a valid reference to the intermediate object
+                //@TODO: Handle the relationship between this model and a "through" model created in the same fill operation
+                //@TODO: (?) Handle chained HasManyThrough relationships, and save the models in the correct order
                 foreach ($input as $sub_input) {
                     $relation_repository->setInput($sub_input)->save();
                 }

--- a/src/EloquentRepository.php
+++ b/src/EloquentRepository.php
@@ -398,6 +398,10 @@ class EloquentRepository implements Repository
                         //Process HasManyThrough after all other relationships since it can depend on a related
                         // intermediate object. Ex: Filling in a User that has Posts, and those Posts have a Reaction.
                         // The Post relationship has to process before the Reaction.
+                        //NOTE: The model referred to by $value HAS TO ALREADY EXIST IN THE DATABASE. The input
+                        // data uses nesting to infer parent model and its relationship. HasManyThrough circumvents this
+                        // direct lineage.
+                        //@TODO: Add the ability to refer to a nested chunk of data in input, and force the creation of the parent model first.
                         $late_relations[] = [
                             'relation' => $relation,
                             'value'    => $value

--- a/src/EloquentRepository.php
+++ b/src/EloquentRepository.php
@@ -402,6 +402,7 @@ class EloquentRepository implements Repository
                             'relation' => $relation,
                             'value'    => $value
                         ];
+                        break;
                 }
             } elseif ((in_array($key, $model_fields) || $instance->hasSetMutator($key)) && $access_compiler->isFillable($key)) {
                 $instance->{$key} = $value;

--- a/src/EloquentRepository.php
+++ b/src/EloquentRepository.php
@@ -395,6 +395,9 @@ class EloquentRepository implements Repository
                         ];
                         break;
                     case HasManyThrough::class:
+                        //Process HasManyThrough after all other relationships since it can depend on a related
+                        // intermediate object. Ex: Filling in a User that has Posts, and those Posts have a Reaction.
+                        // The Post relationship has to process before the Reaction.
                         $late_relations[] = [
                             'relation' => $relation,
                             'value'    => $value

--- a/src/Utility/RouteGuessingModelResolver.php
+++ b/src/Utility/RouteGuessingModelResolver.php
@@ -4,10 +4,10 @@ namespace Koala\Pouch\Utility;
 
 use Koala\Pouch\Contracts\PouchResource;
 use Koala\Pouch\Contracts\ModelResolver;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\App;
+use Koala\Pouch\Exception\ModelNotResolvedException;
 
 /**
  * Class RouteGuessingModelResolver
@@ -30,7 +30,7 @@ class RouteGuessingModelResolver implements ModelResolver
         $route_name = $route->getName();
 
         if (! is_null($route_name) && strpos($route_name, '.') !== false) {
-            list(, $alias) = Arr::reverse(explode('.', $route->getName()));
+            list(, $alias) = array_reverse(explode('.', $route_name) ?: []);
 
             $model_class = $this->namespaceModel(Str::studly(Str::singular($alias)));
 
@@ -41,7 +41,7 @@ class RouteGuessingModelResolver implements ModelResolver
             throw new \LogicException(sprintf('%s must be an instance of %s', $model_class, PouchResource::class));
         }
 
-        throw new \LogicException('Unable to resolve model from improperly named route');
+        throw new ModelNotResolvedException('Unable to resolve model from improperly named route');
     }
 
     /**

--- a/src/Utility/RouteGuessingModelResolver.php
+++ b/src/Utility/RouteGuessingModelResolver.php
@@ -7,7 +7,7 @@ use Koala\Pouch\Contracts\ModelResolver;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Routing\Route;
-use Illuminate\Console\AppNamespaceDetectorTrait;
+use Illuminate\Support\Facades\App;
 
 /**
  * Class RouteGuessingModelResolver
@@ -18,8 +18,6 @@ use Illuminate\Console\AppNamespaceDetectorTrait;
  */
 class RouteGuessingModelResolver implements ModelResolver
 {
-    use AppNamespaceDetectorTrait;
-
     /**
      * Resolve and return the model class for requests.
      *
@@ -54,6 +52,6 @@ class RouteGuessingModelResolver implements ModelResolver
      */
     final public function namespaceModel($model_class)
     {
-        return sprintf('%s%s', $this->getAppNamespace(), $model_class);
+        return sprintf('%s%s', App::getNamespace(), $model_class);
     }
 }

--- a/src/Utility/RouteGuessingModelResolver.php
+++ b/src/Utility/RouteGuessingModelResolver.php
@@ -30,7 +30,7 @@ class RouteGuessingModelResolver implements ModelResolver
         $route_name = $route->getName();
 
         if (! is_null($route_name) && strpos($route_name, '.') !== false) {
-            list(, $alias) = array_reverse(explode('.', $route_name) ?: []);
+            $alias = (explode('.', $route_name) ?: [])[1] ?? "";
 
             $model_class = $this->namespaceModel(Str::studly(Str::singular($alias)));
 

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -282,12 +282,12 @@ class EloquentRepositoryTest extends DBTestCase
 
         $user = $this->getRepository(User::class, [
             'username' => 'joe',
-            'posts'      => [
+            'posts'    => [
                 [
                     'id' => $postId
                 ]
             ],
-            'reactions'  => [
+            'reactions' => [
                 ['name' => 'Jar Jar Binks', 'icon' => 'lol', 'post_id' => $postId],
                 ['name' => 'Darth Maul', 'icon' => 'skull-and-crossbones', 'post_id' => $postId],
             ]
@@ -301,8 +301,8 @@ class EloquentRepositoryTest extends DBTestCase
 
         //Another user with the same id, same post, and an additional reaction
         $user = $this->getRepository(User::class, [
-            'id'    => $user->id,
-            'reactions'  => [
+            'id'        => $user->id,
+            'reactions' => [
                 ['name' => 'Han Solo', 'icon' => 'gun', 'post_id' => $postId],
                 ['name' => 'Biggs', 'icon' => 'boom', 'post_id' => 2],
             ],

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -909,7 +909,7 @@ class EloquentRepositoryTest extends DBTestCase
          * Sort depth 1, expect sorting by post title, desc alphabetical
          */
         $searchString = '#mysonistheworst';
-        $repository  = $this->getRepository(User::class);
+        $repository   = $this->getRepository(User::class);
         $repository->modify()
             ->setFilters((['posts.tags.label' => '='.$searchString]))
             ->setSortOrder(['reactions.name' => $direction]);

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -302,13 +302,13 @@ class EloquentRepositoryTest extends DBTestCase
         //Another user with the same id, same post, and an additional reaction
         $user = $this->getRepository(User::class, [
             'id'    => $user->id,
-            'posts' => [
-                ['id' => $postId],
-                ['id' => 2],
-            ],
             'reactions'  => [
                 ['name' => 'Han Solo', 'icon' => 'gun', 'post_id' => $postId],
                 ['name' => 'Biggs', 'icon' => 'boom', 'post_id' => 2],
+            ],
+            'posts' => [
+                ['id' => $postId],
+                ['id' => 2],
             ]
         ])->save();
 
@@ -868,8 +868,7 @@ class EloquentRepositoryTest extends DBTestCase
          */
         $repository = $this->getRepository(User::class);
         $repository->modify()
-            ->setSortOrder(['reactions.name' => $direction])
-            ->setEagerLoads(['reactions']);
+            ->setSortOrder(['reactions.name' => $direction]);
         $users = $repository->all();
 
         $this->assertCount(User::count(), $users->pluck('name')->unique());

--- a/tests/EloquentRepositoryTest.php
+++ b/tests/EloquentRepositoryTest.php
@@ -2,11 +2,9 @@
 
 namespace Koala\Pouch\Tests;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schema;
 use Koala\Pouch\Contracts\AccessControl;
-use Koala\Pouch\Tests\Models\Reaction;
 use Koala\Pouch\Tests\Models\Tag;
 use Koala\Pouch\Tests\Seeds\FilterDataSeeder;
 use Illuminate\Database\Eloquent\Collection;

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -865,6 +865,25 @@ class FilterTest extends DBTestCase
         }
     }
 
+    /**
+     * Check to see if filtering by id works with a many to many relationship.
+     */
+    public function testItFiltersNestedHasManyThroughRelationships()
+    {
+        $filters = ['reactions.icon' => '=sick'];
+
+        $model   = User::class;
+        $query   = $this->getQuery($model);
+        $columns = $this->getModelColumns($model);
+
+        Filter::applyQueryFilters($query, $filters, $columns, (new $model())->getTable());
+
+        $results = $query->get();
+
+        $this->assertEquals(1, count($results));
+        $this->assertEquals('solocup@galaxyfarfaraway.com', $results->first()->username);
+    }
+
     public function testItFiltersNestedConjuctions()
     {
         $filters = [

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -34,7 +34,7 @@ class Post extends Model implements PouchResource
         'hands',
         'occupation',
         'times_captured',
-        'posts.label',
+        'posts.label'
     ];
 
     /**

--- a/tests/Models/Reaction.php
+++ b/tests/Models/Reaction.php
@@ -5,70 +5,74 @@ namespace Koala\Pouch\Tests\Models;
 use Koala\Pouch\Contracts\PouchResource;
 use Illuminate\Database\Eloquent\Model;
 
-class Post extends Model implements PouchResource
+class Reaction extends Model implements PouchResource
 {
     /**
      * @const array
      */
     public const FILLABLE = [
-        'title',
-        'user_id',
-        'user',
-        'tags',
+        'name',
+        'icon',
+        'comment',
+        'post_id'
     ];
 
     /**
      * @const array
      */
     public const INCLUDABLE = [
-        'user',
-        'tags',
+        'post',
     ];
 
     /**
      * @const array
      */
     public const FILTERABLE = [
-        'username',
         'name',
-        'hands',
-        'occupation',
-        'times_captured',
-        'posts.label',
+        'icon',
+        'comment'
     ];
 
     /**
      * @var string
      */
-    protected $table = 'posts';
+
+    protected $fillable = self::FILLABLE;
+
+    protected $hidden = [
+        'laravel_through_key'
+    ];
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
-    public function not_includable()
+    public function post()
     {
-        return $this->belongsTo(NotIncludable::class);
+        return $this->HasOne(Post::class);
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * For unit testing purposes
+     *
+     * @return array
      */
-    public function user()
+    public function getFillable()
     {
-        return $this->belongsTo(User::class);
+        return $this->fillable;
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * For unit testing purposes
+     *
+     * @param array $fillable
+     *
+     * @return $this
      */
-    public function tags()
+    public function setFillable(array $fillable)
     {
-        return $this->belongsToMany(Tag::class)->withPivot('extra');
-    }
+        $this->fillable = $fillable;
 
-    public function reactions()
-    {
-        return $this->hasMany(Reaction::class);
+        return $this;
     }
 
     /**

--- a/tests/Models/Tag.php
+++ b/tests/Models/Tag.php
@@ -13,6 +13,7 @@ class Tag extends Model implements PouchResource
     public const FILLABLE = [
         'label',
         'posts',
+        'color'
     ];
 
     /**
@@ -29,6 +30,7 @@ class Tag extends Model implements PouchResource
         'hands',
         'occupation',
         'times_captured',
+        'color',
         'posts.label',
     ];
 
@@ -43,6 +45,7 @@ class Tag extends Model implements PouchResource
     protected $fillable = [
         'label',
         'posts',
+        'color'
     ];
 
     /**

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -21,7 +21,7 @@ class User extends Model implements PouchResource
         'times_captured',
         'posts',
         'profile',
-        'reactions' //Usually something that wouldn't be fillable in real life, but this is for testing purposes
+        'reactions'
     ];
 
     /**
@@ -46,6 +46,9 @@ class User extends Model implements PouchResource
         'posts.tags',
         'posts.tags.label',
         'profile.is_human',
+        'reactions.name',
+        'reactions.icon',
+        'reactions.comment'
     ];
 
     protected $casts = [

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -21,6 +21,7 @@ class User extends Model implements PouchResource
         'times_captured',
         'posts',
         'profile',
+        'reactions' //Usually something that wouldn't be fillable in real life, but this is for testing purposes
     ];
 
     /**
@@ -73,6 +74,11 @@ class User extends Model implements PouchResource
     public function profile()
     {
         return $this->hasOne(Profile::class);
+    }
+
+    public function reactions()
+    {
+        return $this->hasManyThrough(Reaction::class, Post::class);
     }
 
     /**

--- a/tests/Models/V1/NotAPouchResource.php
+++ b/tests/Models/V1/NotAPouchResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Koala\Pouch\Tests\Models\V1;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NotAPouchResource extends Model
+{
+    /**
+     * @const array
+     */
+    public const FILLABLE = [];
+
+    /**
+     * @const array
+     */
+    public const INCLUDABLE = [];
+
+    /**
+     * @const array
+     */
+    public const FILTERABLE = [];
+
+    /**
+     * @var string
+     */
+    protected $table = 'users';
+}

--- a/tests/RouteGuessingModelResolverTest.php
+++ b/tests/RouteGuessingModelResolverTest.php
@@ -32,11 +32,9 @@ class RouteGuessingModelResolverTest extends TestCase
     public function routeNameAndModelClassProvider(): array
     {
         return [
-          ['users.v1', User::class],
-          ['users.posts.v1', Post::class],
-          ['users.posts.tags', Post::class],
-          ['users.posts.tags.v1', Tag::class],
-          ['user.post.tag.v1', Tag::class],
+          ['v1.users', User::class],
+          ['v1.user', User::class],
+          ['v1.users.posts', User::class] //@TODO: Should the route guess Post::class? There is not any documentation on route naming convention
         ];
     }
 

--- a/tests/RouteGuessingModelResolverTest.php
+++ b/tests/RouteGuessingModelResolverTest.php
@@ -8,7 +8,6 @@ use Koala\Pouch\Exception\ModelNotResolvedException;
 use Koala\Pouch\Tests\Models\Post;
 use Koala\Pouch\Tests\Models\Tag;
 use Koala\Pouch\Tests\Models\User;
-use Illuminate\Routing\Controller;
 use Illuminate\Routing\Route;
 use Koala\Pouch\Utility\RouteGuessingModelResolver;
 use Mockery;

--- a/tests/RouteGuessingModelResolverTest.php
+++ b/tests/RouteGuessingModelResolverTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Koala\Pouch\Tests;
+
+use Illuminate\Support\Facades\App;
+use Koala\Pouch\Contracts\PouchResource;
+use Koala\Pouch\Exception\ModelNotResolvedException;
+use Koala\Pouch\Tests\Models\Post;
+use Koala\Pouch\Tests\Models\Tag;
+use Koala\Pouch\Tests\Models\User;
+use Illuminate\Routing\Controller;
+use Illuminate\Routing\Route;
+use Koala\Pouch\Utility\RouteGuessingModelResolver;
+use Mockery;
+
+class RouteGuessingModelResolverTest extends TestCase
+{
+    /**
+     * @dataProvider routeNameAndModelClassProvider
+     */
+    public function testCanResolveModelClassFromRouteName(string $routeName, string $modelClass)
+    {
+        $route = Mockery::mock(Route::class)
+            ->shouldReceive('getName')->atLeast()->once()->andReturn($routeName)
+            ->getMock();
+        App::shouldReceive('getNamespace')->once()->andReturn(__NAMESPACE__.'\\Models\\');
+
+        $model = (new RouteGuessingModelResolver())->resolveModelClass($route);
+
+        $this->assertEquals($modelClass, $model);
+    }
+
+    public function routeNameAndModelClassProvider(): array
+    {
+        return [
+          ['users.v1', User::class],
+          ['users.posts.v1', Post::class],
+          ['users.posts.tags', Post::class],
+          ['users.posts.tags.v1', Tag::class],
+        ];
+    }
+
+    public function testItThrowsAnExceptionIfTheModelCannotBeResolvedFromTheRouteName()
+    {
+        $route = Mockery::mock(Route::class)
+            ->shouldReceive('getName')->atLeast()->once()->andReturn('foobar')
+            ->getMock();
+
+        $this->expectExceptionObject(new ModelNotResolvedException('Unable to resolve model from improperly named route'));
+        (new RouteGuessingModelResolver())->resolveModelClass($route);
+    }
+
+    public function testItThrowsAnExceptionIfTheResolvedModelDoesNotExtendPouchResource()
+    {
+        $route = Mockery::mock(Route::class)
+            ->shouldReceive('getName')->once()->andReturn('not_a_pouch_resource.v1')
+            ->getMock();
+        App::shouldReceive('getNamespace')->once()->andReturn(__NAMESPACE__.'\\Models\\');
+
+        $this->expectExceptionObject(new \LogicException(__NAMESPACE__.'\\Models\\NotAPouchResource must be an instance of ' . PouchResource::class));
+        (new RouteGuessingModelResolver())->resolveModelClass($route);
+    }
+}
+
+
+/**
+ * Class UserController
+ *
+ * @package Koala\Pouch\Tests
+ */
+class UserController extends Controller
+{
+    public static $resource = User::class;
+}
+
+class RouteGuessingModelResolverTestStubControllerNoResource
+{
+}

--- a/tests/RouteGuessingModelResolverTest.php
+++ b/tests/RouteGuessingModelResolverTest.php
@@ -62,18 +62,3 @@ class RouteGuessingModelResolverTest extends TestCase
         (new RouteGuessingModelResolver())->resolveModelClass($route);
     }
 }
-
-
-/**
- * Class UserController
- *
- * @package Koala\Pouch\Tests
- */
-class UserController extends Controller
-{
-    public static $resource = User::class;
-}
-
-class RouteGuessingModelResolverTestStubControllerNoResource
-{
-}

--- a/tests/RouteGuessingModelResolverTest.php
+++ b/tests/RouteGuessingModelResolverTest.php
@@ -37,6 +37,7 @@ class RouteGuessingModelResolverTest extends TestCase
           ['users.posts.v1', Post::class],
           ['users.posts.tags', Post::class],
           ['users.posts.tags.v1', Tag::class],
+          ['user.post.tag.v1', Tag::class],
         ];
     }
 

--- a/tests/RouteGuessingModelResolverTest.php
+++ b/tests/RouteGuessingModelResolverTest.php
@@ -51,7 +51,7 @@ class RouteGuessingModelResolverTest extends TestCase
     public function testItThrowsAnExceptionIfTheResolvedModelDoesNotExtendPouchResource()
     {
         $route = Mockery::mock(Route::class)
-            ->shouldReceive('getName')->once()->andReturn('not_a_pouch_resource.v1')
+            ->shouldReceive('getName')->once()->andReturn('v1.not_a_pouch_resource')
             ->getMock();
         App::shouldReceive('getNamespace')->once()->andReturn(__NAMESPACE__.'\\Models\\');
 

--- a/tests/migrations/2022_11_30_015706_create_reactions_table.php
+++ b/tests/migrations/2022_11_30_015706_create_reactions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateReactionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reactions', function (Blueprint $table) {
+            $table->id();
+            $table->text('name');
+            $table->text('icon');
+            $table->text('comment')->nullable();
+            $table->foreignIdFor(\Koala\Pouch\Tests\Models\Post::class);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('reactions');
+    }
+}

--- a/tests/migrations/2022_11_30_025012_add_color_to_tags_table.php
+++ b/tests/migrations/2022_11_30_025012_add_color_to_tags_table.php
@@ -14,7 +14,7 @@ class AddColorToTagsTable extends Migration
     public function up()
     {
         Schema::table('tags', function (Blueprint $table) {
-           $table->text('color')->nullable();
+            $table->text('color')->nullable();
         });
     }
 

--- a/tests/migrations/2022_11_30_025012_add_color_to_tags_table.php
+++ b/tests/migrations/2022_11_30_025012_add_color_to_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColorToTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tags', function (Blueprint $table) {
+           $table->text('color')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->dropColumn('color');
+        });
+    }
+}

--- a/tests/seeds/FilterDataSeeder.php
+++ b/tests/seeds/FilterDataSeeder.php
@@ -47,8 +47,8 @@ class FilterDataSeeder extends Seeder
 
             if (isset($user['posts'])) {
                 foreach ($user['posts'] as $post) {
-                    $post_instance = new Post();
-                    $post_instance->title = $post['title'];
+                    $post_instance          = new Post();
+                    $post_instance->title   = $post['title'];
                     $post_instance->user_id = $user_instance->id;
                     $post_instance->save();
 

--- a/tests/seeds/FilterDataSeeder.php
+++ b/tests/seeds/FilterDataSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Koala\Pouch\Tests\Seeds;
 
+use Koala\Pouch\Tests\Models\Reaction;
 use Koala\Pouch\Tests\Models\Post;
 use Koala\Pouch\Tests\Models\Profile;
 use Koala\Pouch\Tests\Models\Tag;
@@ -51,6 +52,14 @@ class FilterDataSeeder extends Seeder
                     $post_instance->user_id = $user_instance->id;
                     $post_instance->save();
 
+                    foreach ($post['reactions'] ?? [] as $reaction) {
+                        Reaction::firstOrCreate(
+                            ['name' => $reaction['name'], 'post_id' => $post_instance->id],
+                            ['icon' => $reaction['icon'], 'comment' => $reaction['comment'] ?? null]
+                        );
+                    }
+                }
+
                     $tag_ids = [];
                     foreach ($post['tags'] as $tag) {
                         $tag_instance = Tag::firstOrCreate(
@@ -64,17 +73,8 @@ class FilterDataSeeder extends Seeder
                     }
 
                     $post_instance->tags()->sync($tag_ids);
-                }
             }
         }
-
-        $users = User::with(
-            [
-                'profile',
-                'posts.tags'
-            ]
-        )->get()->toArray();
-        $test = 'test';
     }
 
     public function users()
@@ -95,8 +95,11 @@ class FilterDataSeeder extends Seeder
                     [
                         'title' => 'I Kissed a Princess and I Liked it',
                         'tags'  => [
-                            ['label' => '#peace',],
+                            ['label' => '#peace', 'color' => 'green'],
                             ['label' => '#thelastjedi',]
+                        ],
+                        'reactions' => [
+                            ['name' => 'Obi-Wan Kenobi', 'icon' => 'wave', 'comment' => 'Hello there.']
                         ]
                     ]
                 ]
@@ -118,6 +121,9 @@ class FilterDataSeeder extends Seeder
                         'tags'  => [
                             ['label' => '#princess',],
                             ['label' => '#mysonistheworst',],
+                        ],
+                        'reactions' => [
+                            ['name' => 'Han Solo', 'icon' => 'heart', 'comment' => 'I know.']
                         ]
                     ]
                 ]
@@ -140,12 +146,16 @@ class FilterDataSeeder extends Seeder
                             ['label' => '#iknow',],
                             ['label' => '#triggerfinger',],
                             ['label' => '#mysonistheworst',],
+                        ],
+                        'coauthors' => [
+                            ['name' => 'Chewbacca', 'icon' => 'thumbs-up'],
+                            ['name' => 'Luke Skywalker', 'icon' => 'sick', 'comment' => 'Do you know how to get tauntaun odor out of clothes?']
                         ]
                     ],
                     [
                         'title' => '99 Problems But A Hutt Ain\'t One',
                         'tags'  => [
-                            ['label' => '#og'],
+                            ['label' => '#og', 'color' => 'green'],
                             ['label' => '#99']
                         ]
                     ]

--- a/tests/seeds/FilterDataSeeder.php
+++ b/tests/seeds/FilterDataSeeder.php
@@ -47,8 +47,8 @@ class FilterDataSeeder extends Seeder
 
             if (isset($user['posts'])) {
                 foreach ($user['posts'] as $post) {
-                    $post_instance          = new Post();
-                    $post_instance->title   = $post['title'];
+                    $post_instance = new Post();
+                    $post_instance->title = $post['title'];
                     $post_instance->user_id = $user_instance->id;
                     $post_instance->save();
 
@@ -58,7 +58,6 @@ class FilterDataSeeder extends Seeder
                             ['icon' => $reaction['icon'], 'comment' => $reaction['comment'] ?? null]
                         );
                     }
-                }
 
                     $tag_ids = [];
                     foreach ($post['tags'] as $tag) {
@@ -73,6 +72,7 @@ class FilterDataSeeder extends Seeder
                     }
 
                     $post_instance->tags()->sync($tag_ids);
+                }
             }
         }
     }
@@ -147,7 +147,7 @@ class FilterDataSeeder extends Seeder
                             ['label' => '#triggerfinger',],
                             ['label' => '#mysonistheworst',],
                         ],
-                        'coauthors' => [
+                        'reactions' => [
                             ['name' => 'Chewbacca', 'icon' => 'thumbs-up'],
                             ['name' => 'Luke Skywalker', 'icon' => 'sick', 'comment' => 'Do you know how to get tauntaun odor out of clothes?']
                         ]

--- a/tests/seeds/FilterDataSeederTest.php
+++ b/tests/seeds/FilterDataSeederTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Koala\Pouch\Tests\Seeds;
+
+use Illuminate\Support\Facades\Artisan;
+use Koala\Pouch\Tests\DBTestCase;
+use Koala\Pouch\Tests\Models\Post;
+use Koala\Pouch\Tests\Models\Reaction;
+use Koala\Pouch\Tests\Models\Tag;
+use Koala\Pouch\Tests\Models\User;
+
+class FilterDataSeederTest extends DBTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Artisan::call('db:seed', [
+            '--class' => FilterDataSeeder::class
+        ]);
+    }
+
+    public function testItCanSeedUsers()
+    {
+        $this->assertNotEmpty(User::all());
+        $this->assertNotEmpty(Post::all());
+        $this->assertNotEmpty(Tag::all());
+        $this->assertNotEmpty(Reaction::all());
+
+        $user = User::first();
+
+        $this->assertNotEmpty($user->posts);
+        $this->assertNotEmpty($user->reactions);
+    }
+}


### PR DESCRIPTION
# What

Adds full support for Repositories that use models that contain a `HasManyThrough` relationship.

# Why

`EloquentRepository` already  supports filtering through fields that live in any Eloquent relationship. But, it lacks in these ways:
* It is unable to apply sorts and aggregations using a field that is found through a `HasManyThrough` relationship
* It cannot accept data to create a new model that is connected through a `HasManyThrough` relationship.

# How
### Full support for sort and aggregation with fields defined through a `HasManyThrough` relationship
#### `EloquentQueryModifier::applyNestedJoins` - Added a case join HasManyThrough related data - the "through" model and the "far" model - so the fields are accessible when used as a sort or aggregation.

### Preliminary support for the creation of models related through `HasManyThrough` 
#### `EloquentRepository::fill()`
The ability to create related child models lives here. 

Related models are filled and associated according to how the input data is nested.

An example with directly nested model data: 
A `User` "`HasMany`" `Post`s. And, a `Post` "`HasMany`" `Reaction`s. 
The `posts` are directly nested under under the user, and the `reactions` are nested directly under `posts`, so the relationship is easily known when it is time to create models and link them. 
```
(new EloquentRepository(User::class, [ //Root-level fields will be assigned to the `User` model
    'username' => 'joe',
        'posts'    => [                 //Matches the name of the relationship defined in `User`
                [
                    'label' => 'First Post!', 
                    'reactions' => [     //Matches the name of the relationship defined in 'Post'
                        ['name' => 'John Doe', 'icon' => 'thumbs-up'
                    ]
                ]
            ]
        ]
    )->save();
```

And, an example with a `HasManyThrough` relationship: 
`HasManyThrough` relationships make the relationship more difficult to parse. In this example,  a `User` has many `Reaction`s through their `Post`s. The `Post` still has the `HasMany` relationship with `Reaction`s. But the "through" relationship is not apparent.

**There is an assumption that a `Post` with `post_id` already exists.
TODO: Come up with a language in this fill body to relate a not-yet-created `reactions` model to a not-yet-created `posts` model. Create models in the fill action in an order where a new "through" model (in this case `posts`) is created first, and the `reactions` model is created last and contains the `posts` id.**

```
(new EloquentRepository(User::class, [
    'username' => 'joe',
        'posts'    => [
                [
                    'label' => 'First Post'
                ]
            ]
        ],
        'reactions` => [      //Matches the relationship name defined in `User`
            ['post_id' => 1, 'name' => "John Doe", 'icon' => 'thumbs-up']
        ]
    )->save();
```

#### `EloquentRepository::cascadeRelations`
This is where the related models created in `EloquentRepository::fill()` are saved along with their relationships with other models. The persistence of Models that were created because of a `HasManyThrough` relationship are delayed until all other related models are saved. There is the same assumption that the "through" model already exists.
TODO: Handle cases where the "through" model is part of the same fill operation, and the id is not yet known until the "through" model is saved.
TODO: Properly handle chained `HasManyThrough` relationships, and save the models in the correct order.



# CC 🐨
