### PR TITLE
Clean up aggregate query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
-          tools: php-cs-fixer
+          tools: php-cs-fixer:3.4
       - name: Run Lint Check
         run: php-cs-fixer fix --dry-run -vv --diff --config=.php_cs.dist.php
   phan:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
 	"require-dev": {
 		"phpunit/phpunit": "^9",
 		"orchestra/testbench": "^6",
-		"mockery/mockery": "^1"
+		"mockery/mockery": "^1",
+		"friendsofphp/php-cs-fixer": "3.4.*"
 	},
 	"authors": [
 		{

--- a/src/EloquentQueryModifier.php
+++ b/src/EloquentQueryModifier.php
@@ -360,8 +360,6 @@ class EloquentQueryModifier implements QueryModifier
                 $this->query()->addSelect($valid_group);
             }
         }
-
-        var_dump($this->query()->toSql());
     }
 
     /**

--- a/src/EloquentQueryModifier.php
+++ b/src/EloquentQueryModifier.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**
@@ -356,12 +355,13 @@ class EloquentQueryModifier implements QueryModifier
 
         if (in_array($function, $allowed_aggregations, true) && in_array($column, $allowed_columns, true)) {
             $this->query()->getQuery()->aggregate = ['columns' => [$column], 'function' => $function];
-            $this->query()->getQuery()->aggregate = ['columns' => [$column], 'function' => $function];
 
             if (! empty($valid_group)) {
                 $this->query()->addSelect($valid_group);
             }
         }
+
+        var_dump($this->query()->toSql());
     }
 
     /**

--- a/src/EloquentQueryModifier.php
+++ b/src/EloquentQueryModifier.php
@@ -257,7 +257,7 @@ class EloquentQueryModifier implements QueryModifier
     /**
      * Set aggregate functions.
      *
-     * @param array $aggregate
+     * @param array<array{0: string, 1: string}> $aggregate
      *
      * @return \Koala\Pouch\Contracts\QueryModifier
      */
@@ -355,7 +355,8 @@ class EloquentQueryModifier implements QueryModifier
         $function        = strtolower(key($aggregate));
 
         if (in_array($function, $allowed_aggregations, true) && in_array($column, $allowed_columns, true)) {
-            $this->query()->addSelect(DB::raw($function . '(' . $column . ') as aggregate'));
+            $this->query()->getQuery()->aggregate = ['columns' => [$column], 'function' => $function];
+            $this->query()->getQuery()->aggregate = ['columns' => [$column], 'function' => $function];
 
             if (! empty($valid_group)) {
                 $this->query()->addSelect($valid_group);

--- a/tests/EloquentQueryModifierTest.php
+++ b/tests/EloquentQueryModifierTest.php
@@ -81,10 +81,10 @@ class EloquentQueryModifierTest extends DBTestCase
         $query = $model->query();
 
         (new EloquentQueryModifier())->setQuery($query)
-            ->setAggregate(['sum' => 'hands'])
+            ->setAggregate([$function => 'hands'])
             ->apply(new EloquentAccessControl(), get_class($model));
 
-        $this->assertEqualsCanonicalizing(['function' => 'sum', 'columns' => ['hands']], $query->getQuery()->aggregate);
+        $this->assertEqualsCanonicalizing(['function' => $function, 'columns' => ['hands']], $query->getQuery()->aggregate);
     }
 
     public function testItOnlyAppliesTheFirstAggregation()

--- a/tests/EloquentQueryModifierTest.php
+++ b/tests/EloquentQueryModifierTest.php
@@ -39,13 +39,8 @@ class EloquentQueryModifierTest extends DBTestCase
 
     public function testItDoesNotApplySelectWhenThereAreNoPicksDefined()
     {
-        Artisan::call('db:seed', [
-            '--class' => FilterDataSeeder::class
-        ]);
-
-        /** @var Model $model */
-        $model = User::findOrFail(1);
-        $query = $model->newQuery();
+        $model = new User();
+        $query = $model->query();
 
         (new EloquentQueryModifier())->setQuery($query)->apply(new EloquentAccessControl(), get_class($model));
 
@@ -54,13 +49,8 @@ class EloquentQueryModifierTest extends DBTestCase
 
     public function testItDoesNotSelectPicksThatAreNotInTheModelTable()
     {
-        Artisan::call('db:seed', [
-            '--class' => FilterDataSeeder::class
-        ]);
-
-        /** @var Model $model */
-        $model = User::findOrFail(1);
-        $query = $model->newQuery();
+        $model = new User();
+        $query = $model->query();
 
         (new EloquentQueryModifier())->setQuery($query)
             ->setPicks([$model->getKeyName(), 'not-in-this-model'])
@@ -72,18 +62,63 @@ class EloquentQueryModifierTest extends DBTestCase
 
     public function testItDoesNotApplySelectWhenNoneOfThePicksMatchColumns()
     {
-        Artisan::call('db:seed', [
-            '--class' => FilterDataSeeder::class
-        ]);
-
-        /** @var Model $model */
-        $model = User::findOrFail(1);
-        $query = $model->newQuery();
+        $model = new User();
+        $query = $model->query();
 
         (new EloquentQueryModifier())->setQuery($query)
             ->setPicks(['not-in-this-model', 'another-not-in-this-model'])
             ->apply(new EloquentAccessControl(), get_class($model));
 
         $this->assertNull($query->getQuery()->columns);
+    }
+
+    /**
+     * @dataProvider aggregateFunctionDataProvider
+     */
+    public function testItCanApplyAnAggregation(string $function)
+    {
+        $model = new User();
+        $query = $model->query();
+
+        (new EloquentQueryModifier())->setQuery($query)
+            ->setAggregate(['sum' => 'hands'])
+            ->apply(new EloquentAccessControl(), get_class($model));
+
+        $this->assertEqualsCanonicalizing(['function' => 'sum', 'columns' => ['hands']], $query->getQuery()->aggregate);
+    }
+
+    public function testItOnlyAppliesTheFirstAggregation()
+    {
+        $model = new User();
+        $query = $model->query();
+
+        (new EloquentQueryModifier())->setQuery($query)
+            ->setAggregate(['sum' => 'hands', 'avg' => 'hands', 'max' => 'hands'])
+            ->apply(new EloquentAccessControl(), get_class($model));
+
+        $this->assertEqualsCanonicalizing(['function' => 'sum', 'columns' => ['hands']], $query->getQuery()->aggregate);
+    }
+
+    public function testItDoesNotApplyInvalidAggregationFunctions()
+    {
+        $model = new User();
+        $query = $model->query();
+
+        (new EloquentQueryModifier())->setQuery($query)
+            ->setAggregate(['not-valid' => 'hands'])
+            ->apply(new EloquentAccessControl(), get_class($model));
+
+        $this->assertNull($query->getQuery()->aggregate);
+    }
+
+    protected function aggregateFunctionDataProvider()
+    {
+        return [
+            'Count' => ['count'],
+            'Min' => ['min'],
+            'Max' => ['max'],
+            'Sum' => ['sum'],
+            'Avg' => ['avg']
+        ];
     }
 }


### PR DESCRIPTION
# What

Removes usage of `DB:raw(...)` during aggregation query assembly.

Implemented tests that cover assembly of queries that include aggregation functions, and the results returned by a repository that has an aggregation.

# Why

`DB::raw(...)` is an unsafe, and DB-vendor specific method of adding an aggregation to a query. The Eloquent query builder should be used whenever possible to limit the possibility of SQL injection and to keep Pouch database-agnostic as possible.

# How

Removed `DB::raw(...)` from the aggregation select clause and took advantage of the `\Illuminate\Database\Query\Builder::$aggregate` property to append aggregation to a query. Aggregation functions and columns passed through the `$aggregate` property are safely parsed into the query. 

# CC 🐨
